### PR TITLE
Adding string to schema for zero-valued datetimes.

### DIFF
--- a/tap_pipedrive/schemas/recents/users.json
+++ b/tap_pipedrive/schemas/recents/users.json
@@ -26,8 +26,15 @@
       "type": ["null", "boolean"]
     },
     "last_login": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "anyOf": [
+        {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        {
+          "type": ["null", "string"]
+        }
+      ]
     },
     "created": {
       "type": ["null", "string"],


### PR DESCRIPTION
When a user has been invited, but has not yet logged in, Pipedrive returns their "last_login" datetime in the form `0000-00-00 00:00:00`, which is not a valid datetime and fails the replication.

This extends the schema to allow a raw string value to also move through to be emitted to the target and handled downstream.

Addresses #17 