### PR TITLE
Removing missing fields from being required in schemas

### DIFF
--- a/tap_pipedrive/schemas/recents/dynamic_typing/organizations.json
+++ b/tap_pipedrive/schemas/recents/dynamic_typing/organizations.json
@@ -197,8 +197,6 @@
     "related_lost_deals_count",
     "related_open_deals_count",
     "related_won_deals_count",
-    "timeline_last_activity_time",
-    "timeline_last_activity_time_by_owner",
     "undone_activities_count",
     "update_time",
     "visible_to",

--- a/tap_pipedrive/schemas/recents/dynamic_typing/persons.json
+++ b/tap_pipedrive/schemas/recents/dynamic_typing/persons.json
@@ -219,8 +219,6 @@
     "related_lost_deals_count",
     "related_open_deals_count",
     "related_won_deals_count",
-    "timeline_last_activity_time",
-    "timeline_last_activity_time_by_owner",
     "undone_activities_count",
     "update_time",
     "visible_to",


### PR DESCRIPTION
Changes to schema to address #20 and #19 issue of missing fields when the schema is validated against the records via the target.

These two fields aren't returned by default from a brand new Pipedrive account, so the tap should handle them as extras, rather than the required standard.