### PR TITLE
Removes  and  from required fields in organizations schema

### DIFF
--- a/tap_pipedrive/schemas/recents/dynamic_typing/organizations.json
+++ b/tap_pipedrive/schemas/recents/dynamic_typing/organizations.json
@@ -197,8 +197,6 @@
     "related_lost_deals_count",
     "related_open_deals_count",
     "related_won_deals_count",
-    "timeline_last_activity_time",
-    "timeline_last_activity_time_by_owner",
     "undone_activities_count",
     "update_time",
     "visible_to",


### PR DESCRIPTION
Addresses https://github.com/singer-io/tap-pipedrive/issues/19.

Unfortunately this addresses the symptom of the issue. I was unable to reproduce the issue locally, but I continue to see it with the version running on Stitch. Further, I couldn't find any reference to these fields anywhere in the Pipedrive API. I've asked about this on the Pipedrive API forums here: https://devcommunity.pipedrive.com/t/changes-to-timeline-fields-returned-with-organizations-fetched-from-recents-endpoint/492