### PR TITLE
added dealflow.py and associated modifications

### DIFF
--- a/tap_pipedrive/schemas/dealflow.json
+++ b/tap_pipedrive/schemas/dealflow.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    
+    "item_id": {
+      "type": "integer"
+    },
+
+    "user_id": {
+      "type": "integer"
+    },
+ 
+    "field_key": {
+      "type": ["null", "string"]
+    },
+
+    "old_value": {
+      "type": ["null", "string"]
+    },
+
+    "new_value": {
+      "type": ["null", "string"]
+    },
+
+    "is_bulk_update_flag": {
+      "type": ["null", "boolean"]
+    },
+
+    "log_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+
+    "change_source": {
+      "type": ["null", "string"]
+    },
+
+    "additional_data": {
+      "type": ["null", "string", "array", "object"]
+    }
+  }
+}

--- a/tap_pipedrive/schemas/dealflow.json
+++ b/tap_pipedrive/schemas/dealflow.json
@@ -39,7 +39,7 @@
     },
 
     "additional_data": {
-      "type": ["null", "string", "array", "object"]
+      "type": ["null", "string"]
     }
   }
 }

--- a/tap_pipedrive/streams/__init__.py
+++ b/tap_pipedrive/streams/__init__.py
@@ -13,11 +13,12 @@ from .recents.dynamic_typing.deals import RecentDealsStream
 from .recents.dynamic_typing.organizations import RecentOrganizationsStream
 from .recents.dynamic_typing.persons import RecentPersonsStream
 from .recents.dynamic_typing.products import RecentProductsStream
+from .dealflow import DealStageChangeStream
 
 
 __all__ = ['CurrenciesStream', 'ActivityTypesStream', 'FiltersStream', 'StagesStream', 'PipelinesStream',
            'GoalsStream',
            'RecentUsersStream', 'RecentFilesStream', 'RecentDeleteLogsStream'
            'RecentNotesStream', 'RecentActivitiesStream', 'RecentDealsStream', 'RecentOrganizationsStream',
-           'RecentPersonsStream', 'RecentProductsStream',
+           'RecentPersonsStream', 'RecentProductsStream', 'DealStageChangeStream'
            ]

--- a/tap_pipedrive/streams/dealflow.py
+++ b/tap_pipedrive/streams/dealflow.py
@@ -1,0 +1,18 @@
+import singer
+from tap_pipedrive.stream import PipedriveIterStream
+
+class DealStageChangeStream(PipedriveIterStream):
+	base_endpoint = 'deals'
+	id_endpoint = 'deals/{}/flow'
+	schema = 'dealflow'
+	key_properties = ['id', ]
+
+	def get_name(self):
+		return self.schema
+
+	def process_row(self, row):
+		if row['object'] == 'dealChange':
+			return row['data']
+
+	def update_endpoint(self, deal_id):
+		self.endpoint = self.id_endpoint.format(deal_id)

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -74,19 +74,23 @@ class PipedriveTap(object):
             stream.write_schema()
 
             if stream.id_list: # see if we want to iterate over a list of deal_ids
-                all_deal_ids = stream.get_deal_ids(self)
-                is_last_id = False
 
-                for deal_id in all_deal_ids:
-
-                    if deal_id == all_deal_ids[-1]:
+                for deal_id in stream.get_deal_ids(self):
+                    is_last_id = False
+                    if deal_id == stream.these_deals[-1]: #find out if this is last deal_id in the current set
                         is_last_id = True
-
+                    
                     stream.update_endpoint(deal_id)
                     stream.start = 0   # set back to zero for each new deal_id
                     self.do_paginate(stream)
+                    
                     if not is_last_id:
                         stream.more_items_in_collection = True   #set back to True for pagination of next deal_id request
+                    elif is_last_id and stream.more_ids_to_get:  # need to get the next batch of deal_ids
+                        stream.more_items_in_collection = True
+                        stream.start = stream.next_start
+                    else:
+                        stream.more_items_in_collection = False
             else:
                 # paginate
                 self.do_paginate(stream)


### PR DESCRIPTION
### Goal
Stream the deal change transitions so that they can be used for sales funnel metrics. 

### Brief Overview 
We've added a new stream to the tap that will pull out the deal stage change information from the deals/{id}/flow endpoint. This required creating a new module that first gathers all deal_ids from the /deals endpoint. Our changes are as follows: 1) implement if/else statement in tap.py to determine if iterating over a deal_id list is desired; 2) create new PipedriveIterStream class in stream.py to hold the new module that creates that deal_id list; 3) create new dealflow stream (and schema) that includes a module to update the endpoint as you iterate through the deal_id list. 

We tried to construct these new objects such that the PipedriveIterStream object can be used in any scenario where the the endpoint from which a user wants to extract data requires knowledge of a specific deal_id. For example, this could be part of a solution to Issue #28.

Please let us know if you have any feedback, or there are any unit tests we ought to run. (we did test the stream on our own PipeDrive instance before pushing. It is working and all other streams are also still working.)