### PR TITLE
added bookmarking to dealflow

### DIFF
--- a/tap_pipedrive/streams/dealflow.py
+++ b/tap_pipedrive/streams/dealflow.py
@@ -5,10 +5,11 @@ class DealStageChangeStream(PipedriveIterStream):
 	base_endpoint = 'deals'
 	id_endpoint = 'deals/{}/flow'
 	schema = 'dealflow'
+	state_field = 'log_time'
 	key_properties = ['id', ]
 
 	def get_name(self):
-		return self.schema
+	    return self.schema
 
 	def process_row(self, row):
 		if row['object'] == 'dealChange':

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -91,6 +91,8 @@ class PipedriveTap(object):
                         stream.start = stream.next_start
                     else:
                         stream.more_items_in_collection = False
+
+                stream.earliest_state = stream.stream_start
             else:
                 # paginate
                 self.do_paginate(stream)


### PR DESCRIPTION
Added a state_field to dealflow so that the stream will bookmark.
In stream.py, updated selection of deal_ids to gather only those that occur after the bookmark point and before the start of the stream.
In tap.py, after looping over all ids, reset earliest state to the stream start before writing the final state to file. This should mean that the next time the stream syncs, its initial state will be set to the time of the previous stream start.