### PR TITLE
Allow `user_id` to be nullable

### DIFF
--- a/tap_pipedrive/schemas/recents/files.json
+++ b/tap_pipedrive/schemas/recents/files.json
@@ -5,7 +5,7 @@
       "type": "integer"
     },
     "user_id": {
-      "type": "integer"
+      "type": ["null", "integer"]
     },
     "deal_id": {
       "type": ["null", "integer"]


### PR DESCRIPTION
Changes to User schema to address https://github.com/singer-io/tap-pipedrive/issues/46
FROM:
 "user_id": {
      "type": "integer"

TO
"user_id": {
      "type": ["null", "integer"]