### PR TITLE
Add stream/field Selection and deal_products endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,9 @@ setup(name="tap-pipedrive",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_pipedrive"],
       install_requires=[
-          "singer-python==3.6.3",
-          "requests==2.20.0",
+          "pendulum==2.0.4",
+          "requests==2.21.0",
+          "singer-python==5.4.1",
       ],
       entry_points="""
           [console_scripts]

--- a/tap_pipedrive/cli.py
+++ b/tap_pipedrive/cli.py
@@ -10,16 +10,12 @@ logger = singer.get_logger()
 def main_impl():
     args = singer.utils.parse_args(['api_token', 'start_date'])
 
-    if args.properties:
-        logger.error('Tap does not support --properties')
-        exit(1)
+    pipedrive_tap = PipedriveTap(args.config, args.state)
 
     if args.discover:
-        logger.error('Tap does not support -d/--discover')
-        exit(1)
-
-    pipedrive_tap = PipedriveTap(args.config, args.state)
-    pipedrive_tap.do_sync()
+        pipedrive_tap.do_discover()
+    else:
+        pipedrive_tap.do_sync(args.catalog)
 
 
 def main():

--- a/tap_pipedrive/schemas/deal_products.json
+++ b/tap_pipedrive/schemas/deal_products.json
@@ -1,0 +1,124 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "integer"
+      ]
+    },
+    "deal_id": {
+      "type": [
+        "integer"
+      ]
+    },
+    "product_id": {
+      "type": [
+        "integer"
+      ]
+    },
+    "order_nr": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "product_variation_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "item_price": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "discount_percentage": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "duration": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "sum_no_discount": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "sum": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "enabled_flag": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "add_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "formt": "date-time"
+    },
+    "last_edit": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "formt": "date-time"
+    },
+    "comments": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "active_flag": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "sum_formatted": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "quantity_formatted": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "quantity": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
+}

--- a/tap_pipedrive/streams/__init__.py
+++ b/tap_pipedrive/streams/__init__.py
@@ -13,10 +13,11 @@ from .recents.dynamic_typing.organizations import RecentOrganizationsStream
 from .recents.dynamic_typing.persons import RecentPersonsStream
 from .recents.dynamic_typing.products import RecentProductsStream
 from .dealflow import DealStageChangeStream
+from .deal_products import DealsProductsStream
 
 
 __all__ = ['CurrenciesStream', 'ActivityTypesStream', 'FiltersStream', 'StagesStream', 'PipelinesStream',
            'RecentUsersStream', 'RecentFilesStream', 'RecentDeleteLogsStream'
            'RecentNotesStream', 'RecentActivitiesStream', 'RecentDealsStream', 'RecentOrganizationsStream',
-           'RecentPersonsStream', 'RecentProductsStream', 'DealStageChangeStream'
+           'RecentPersonsStream', 'RecentProductsStream', 'DealStageChangeStream', 'DealsProductsStream'
            ]

--- a/tap_pipedrive/streams/deal_products.py
+++ b/tap_pipedrive/streams/deal_products.py
@@ -1,0 +1,15 @@
+import singer
+from tap_pipedrive.stream import PipedriveIterStream
+
+class DealsProductsStream(PipedriveIterStream):
+    base_endpoint = 'deals'
+    id_endpoint = 'deals/{}/products'
+    schema = 'deal_products'
+    state_field = None
+    key_properties = ['id']
+
+    def get_name(self):
+        return self.schema
+
+    def update_endpoint(self, deal_id):
+        self.endpoint = self.id_endpoint.format(deal_id)

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -3,14 +3,14 @@ import pendulum
 import requests
 import singer
 from requests.exceptions import ConnectionError, RequestException
-from json import JSONDecodeError
+#from json import JSONDecodeError
 from singer import set_currently_syncing
 from .config import BASE_URL, CONFIG_DEFAULTS
 from .exceptions import InvalidResponseException
 from .streams import (CurrenciesStream, ActivityTypesStream, FiltersStream, StagesStream, PipelinesStream,
                       RecentNotesStream, RecentUsersStream, RecentActivitiesStream, RecentDealsStream,
                       RecentFilesStream, RecentOrganizationsStream, RecentPersonsStream, RecentProductsStream,
-                      RecentDeleteLogsStream, DealStageChangeStream)
+                      RecentDeleteLogsStream, DealStageChangeStream, DealsProductsStream)
 
 
 logger = singer.get_logger()
@@ -32,7 +32,8 @@ class PipedriveTap(object):
         RecentPersonsStream(),
         RecentProductsStream(),
         RecentDeleteLogsStream(),
-        DealStageChangeStream()
+        DealStageChangeStream(),
+        DealsProductsStream()
     ]
 
     def __init__(self, config, state):

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -1,10 +1,13 @@
+import sys
 import time
+import json
 import pendulum
 import requests
 import singer
 from requests.exceptions import ConnectionError, RequestException
 from json import JSONDecodeError
-from singer import set_currently_syncing
+from singer import set_currently_syncing, metadata
+from singer.catalog import Catalog, CatalogEntry, Schema
 from .config import BASE_URL, CONFIG_DEFAULTS
 from .exceptions import InvalidResponseException
 from .streams import (CurrenciesStream, ActivityTypesStream, FiltersStream, StagesStream, PipelinesStream,
@@ -42,7 +45,42 @@ class PipedriveTap(object):
         self.config['start_date'] = pendulum.parse(self.config['start_date'])
         self.state = state
 
-    def do_sync(self):
+    def do_discover(self):
+        logger.info('Starting discover')
+
+        catalog = Catalog([])
+
+        for stream in self.streams:
+            stream.tap = self
+
+            schema = Schema.from_dict(stream.get_schema())
+            key_properties = stream.key_properties
+
+            metadata = []
+            for prop, json_schema in schema.properties.items():
+                inclusion = 'available'
+                if prop in key_properties:
+                    inclusion = 'automatic'
+                metadata.append({
+                    'breadcrumb': ['properties', prop],
+                    'metadata': {
+                        'inclusion': inclusion
+                    }
+                })
+
+            catalog.streams.append(CatalogEntry(
+                stream=stream.schema,
+                tap_stream_id=stream.schema,
+                key_properties=key_properties,
+                schema=schema,
+                metadata=metadata
+            ))
+
+        json.dump(catalog.to_dict(), sys.stdout, indent=2)
+
+        logger.info('Finished discover')
+
+    def do_sync(self, catalog):
         logger.debug('Starting sync')
 
         # resuming when currently_syncing within state
@@ -50,7 +88,16 @@ class PipedriveTap(object):
         if self.state and 'currently_syncing' in self.state:
             resume_from_stream = self.state['currently_syncing']
 
+        selected_streams = self.get_selected_streams(catalog)
+
+        if 'currently_syncing' in self.state and resume_from_stream not in selected_streams:
+            resume_from_stream = False
+            del self.state['currently_syncing']
+
         for stream in self.streams:
+            if stream.schema not in selected_streams:
+                continue
+
             stream.tap = self
 
             if resume_from_stream:
@@ -101,8 +148,11 @@ class PipedriveTap(object):
                 # set the attribution window so that the bookmark will reflect the new initial_state for the next sync
                 stream.earliest_state = stream.stream_start.subtract(hours=3)
             else:
+                catalog_stream = catalog.get_stream(stream.schema)
+                stream_metadata = metadata.to_map(catalog_stream.metadata)
+
                 # paginate
-                self.do_paginate(stream)
+                self.do_paginate(stream, stream_metadata)
 
             # update state / bookmarking only when supported by stream
             if stream.state_field:
@@ -117,8 +167,16 @@ class PipedriveTap(object):
             pass
         singer.write_state(self.state)
 
+    def get_selected_streams(self, catalog):
+        selected_streams = set()
+        for stream in catalog.streams:
+            mdata = metadata.to_map(stream.metadata)
+            root_metadata = mdata.get(())
+            if root_metadata and root_metadata.get('selected') is True:
+                selected_streams.add(stream.tap_stream_id)
+        return list(selected_streams)
 
-    def do_paginate(self, stream):
+    def do_paginate(self, stream, stream_metadata):
         while stream.has_data():
 
             with singer.metrics.http_request_timer(stream.schema) as timer:
@@ -140,7 +198,7 @@ class PipedriveTap(object):
 
                         if not row: # in case of a non-empty response with an empty element
                             continue
-                        row = optimus_prime.transform(row, stream.get_schema())
+                        row = optimus_prime.transform(row, stream.get_schema(), stream_metadata)
                         if stream.write_record(row):
                             counter.increment()
                         stream.update_state(row)

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -3,7 +3,7 @@ import pendulum
 import requests
 import singer
 from requests.exceptions import ConnectionError, RequestException
-#from json import JSONDecodeError
+from json import JSONDecodeError
 from singer import set_currently_syncing
 from .config import BASE_URL, CONFIG_DEFAULTS
 from .exceptions import InvalidResponseException


### PR DESCRIPTION
- Adds support for `deal_products` stream, allowing end users to relate deals to their products.
- Upgrades singer python and fixes the resulting dependency