### PR TITLE
Fix dealflow error when `add_time` is None

### DIFF
--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -171,7 +171,10 @@ class PipedriveIterStream(PipedriveStream):
     def find_deal_ids(self, data, start, stop):
 
         # find all deals that were *added* after the start time and before the stop time
-        added_ids = [data[i]['id'] for i in range(len(data)) if (start <= pendulum.parse(data[i]['add_time']) < stop)]
+        added_ids = [data[i]['id']
+                     for i in range(len(data))
+                     if (data[i]['add_time'] is not None
+                         and start <= pendulum.parse(data[i]['add_time']) < stop)]
 
         # find all deals that a) had a stage change at any time (i.e., the stage_change_time is not None),
         #                     b) had a stage change after the start time and before the stop time, and


### PR DESCRIPTION
# Description of change
The tap carefully checks whether `stage_change_time` exists before it would use it.
https://github.com/singer-io/tap-pipedrive/blob/feff2e5745069b98adfa9d022663b1ebe4b3b7ea/tap_pipedrive/stream.py#L182
but does not check the same for `add_time`
https://github.com/singer-io/tap-pipedrive/blob/feff2e5745069b98adfa9d022663b1ebe4b3b7ea/tap_pipedrive/stream.py#L174


If an invalid `add_time` is sent to Pipedrive's [Add a deal](https://developers.pipedrive.com/docs/api/v1/#!/Deals/post_deals) endpoint the created deal's `add_time` property will be set to `None` hence the tap needs to guard against this scenario as well.

Example request
```bash
curl --request POST \
  --url 'https://api.pipedrive.com/v1/deals?api_token={PIPEDRIVE_API_TOKEN}' \
  --header 'content-type: application/json' \
  --data '{
	"title": "Test Deal",
	"add_time": "invalid"
}'
```

Example response
```javascript
{
  "success": true,
  "data": {
    "id": 12345,
    "add_time": null,
    "update_time": "2019-11-19 15:20:50",
    // [..]
  },
  // [...]
}
```

Fixes #59

Thanks to @alecdotico and @Itsindigo for helping with this issue.

# Manual QA steps
 - Create a new deal with an empty `add_time` as seen above.
 - Try to extract pipedrive data with the tap.
 - Observe the error: `CRITICAL argument of type 'NoneType' is not iterable` (also in #59)

# Risks
 - n/a
 
# Rollback steps
 - revert this branch
