### PR TITLE
Bump pendulum to 2.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name="tap-pipedrive",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_pipedrive"],
       install_requires=[
-          "pendulum==2.0.4",
+          "pendulum==2.1.2",
           "requests==2.21.0",
           "singer-python==5.4.1",
       ],


### PR DESCRIPTION
### Description of change
Update pendulum to pick up the [fix to a RecursionError issue](https://github.com/sdispater/pendulum/pull/431), encountered when loading / restoring tap state.

### Manual QA steps
 Update results in the issue no longer occurring. Execution against a Pipedrive instance completes as expected.
 
### Risks
Worth a skim of the (few) changes since 2.0.4 outlined in [pendulum release notes](https://github.com/sdispater/pendulum/releases).
 
### Rollback steps
 - revert this branch