### PR TITLE
limit setuptools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-pipedrive
             source /usr/local/share/virtualenvs/tap-pipedrive/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - run:
           name: 'Integration Tests'


### PR DESCRIPTION
# Description of change
Limit setuptools version to enable sourcing venv.

# Manual QA steps
 - None
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
