### PR TITLE
drop slack orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
-orbs:
-  slack: circleci/slack@3.4.2
-
 jobs:
   build:
     docker:
@@ -28,8 +25,6 @@ jobs:
                        --password=$SANDBOX_PASSWORD \
                        --client-id=50 \
                        tap_tester.suites.pipedrive
-      - slack/notify-on-failure:
-          only_for_branches: master
 
 workflows:
   version: 2


### PR DESCRIPTION
# Description of change
Remove the slack orb. It was added prior to the Tiered system. It is firmly in Tier 2.

# Manual QA steps
 - Remove the webhook in the project level settings
 
# Risks
 - None, removing a notification from the circle config.
 
# Rollback steps
 - revert this branch
