### PR TITLE
TDL-12475: Removed support for delete_logs stream

### DIFF
--- a/tap_pipedrive/schemas/recents/delete_log.json
+++ b/tap_pipedrive/schemas/recents/delete_log.json
@@ -1,8 +1,0 @@
-{
-  "type": "object",
-  "properties": {
-    "id": {
-      "type": "integer"
-    }
-  }
-}

--- a/tap_pipedrive/streams/__init__.py
+++ b/tap_pipedrive/streams/__init__.py
@@ -5,7 +5,6 @@ from .stages import StagesStream
 from .pipelines import PipelinesStream
 from .recents.users import RecentUsersStream
 from .recents.files import RecentFilesStream
-from .recents.delete_log import RecentDeleteLogsStream
 from .recents.dynamic_typing.notes import RecentNotesStream
 from .recents.dynamic_typing.activities import RecentActivitiesStream
 from .recents.dynamic_typing.deals import RecentDealsStream
@@ -17,7 +16,7 @@ from .deal_products import DealsProductsStream
 
 
 __all__ = ['CurrenciesStream', 'ActivityTypesStream', 'FiltersStream', 'StagesStream', 'PipelinesStream',
-           'RecentUsersStream', 'RecentFilesStream', 'RecentDeleteLogsStream'
+           'RecentUsersStream', 'RecentFilesStream',
            'RecentNotesStream', 'RecentActivitiesStream', 'RecentDealsStream', 'RecentOrganizationsStream',
            'RecentPersonsStream', 'RecentProductsStream', 'DealStageChangeStream', 'DealsProductsStream'
            ]

--- a/tap_pipedrive/streams/recents/delete_log.py
+++ b/tap_pipedrive/streams/recents/delete_log.py
@@ -1,7 +1,0 @@
-from tap_pipedrive.streams.recents import RecentsStream
-
-
-class RecentDeleteLogsStream(RecentsStream):
-    items = 'delete_log'
-    schema = 'delete_log'
-    key_properties = ['id', ]

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -17,7 +17,7 @@ from .exceptions import (PipedriveError, PipedriveNotFoundError, PipedriveBadReq
 from .streams import (CurrenciesStream, ActivityTypesStream, FiltersStream, StagesStream, PipelinesStream,
                       RecentNotesStream, RecentUsersStream, RecentActivitiesStream, RecentDealsStream,
                       RecentFilesStream, RecentOrganizationsStream, RecentPersonsStream, RecentProductsStream,
-                      RecentDeleteLogsStream, DealStageChangeStream, DealsProductsStream)
+                      DealStageChangeStream, DealsProductsStream)
 
 
 logger = singer.get_logger()
@@ -108,7 +108,6 @@ class PipedriveTap(object):
         RecentOrganizationsStream(),
         RecentPersonsStream(),
         RecentProductsStream(),
-        RecentDeleteLogsStream(),
         DealStageChangeStream(),
         DealsProductsStream()
     ]

--- a/tests/base.py
+++ b/tests/base.py
@@ -125,10 +125,6 @@ class PipedriveBaseTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
             },
-            'delete_log': {
-                self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.FULL_TABLE,
-            },
             'filters': {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,


### PR DESCRIPTION
# Description of change
TDL-12475: Removed support for delete_logs stream as it is no longer supported by Pipedrive

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
