### PR TITLE
Use new stitch-tap-tester in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:
@@ -25,12 +25,6 @@ jobs:
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-pipedrive \
-                       --target=target-stitch \
-                       --orchestrator=stitch-orchestrator \
-                       --email=harrison+sandboxtest@stitchdata.com \
-                       --password=$SANDBOX_PASSWORD \
-                       --client-id=50 \
-                       --token=$STITCH_API_TOKEN \
                        tests
 
 workflows:

--- a/tests/base.py
+++ b/tests/base.py
@@ -53,7 +53,7 @@ class PipedriveBaseTest(unittest.TestCase):
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         return_value = {
-            'start_date' : "2021-04-28T00:00:00Z"
+            'start_date' : "2021-04-29T00:00:00Z"
         }
         if original:
             return return_value


### PR DESCRIPTION
# Description of change
This PR updates the `.circleci` file to run tests using a new tap-tester image

# Manual QA steps
 - 
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
