### PR TITLE
Support for null/empty org names in notes

### DIFF
--- a/tap_pipedrive/schemas/recents/dynamic_typing/notes.json
+++ b/tap_pipedrive/schemas/recents/dynamic_typing/notes.json
@@ -46,7 +46,7 @@
       "type": ["null", "object"],
       "properties": {
         "name": {
-          "type": "string"
+          "type": ["null", "string"]
         }
       }
     },


### PR DESCRIPTION
# Description of change
In natural (in the wild) Pipedrive usage, we can encounter Organization names that aren't (yet) filled in at the time a note is created on Pipedrive.
The current jsonschema rejects such records, which makes the whole sync fail and stop instantly !
Here we're expanding the support by adding null type to organization.name (sub)property.

# Manual QA steps
 - Went through the data to understand what was happening
 - Found quite a few records matching "organization.name is null"
 
# Risks
 - (slightly) more lenient schema validation (but that's the whole point here...)
 
# Rollback steps
 - revert this branch
