### PR TITLE
TDL-18854: Add missing fields

### DIFF
--- a/tap_pipedrive/schemas/recents/dynamic_typing/deals.json
+++ b/tap_pipedrive/schemas/recents/dynamic_typing/deals.json
@@ -183,6 +183,15 @@
     },
     "person_hidden": {
       "type": ["null", "boolean"]
+    },
+    "group_id": {
+      "type": ["null", "integer"]
+    },
+    "group_name": {
+      "type": ["null", "string"]
+    },
+    "renewal_type": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/tap_pipedrive/streams/recents/dynamic_typing/deals.py
+++ b/tap_pipedrive/streams/recents/dynamic_typing/deals.py
@@ -17,4 +17,4 @@ class RecentDealsStream(DynamicTypingRecentsStream):
                      'person_hidden', 'person_id', 'person_name', 'pipeline_id', 'products_count', 'probability',
                      'reference_activities_count', 'rotten_time', 'stage_change_time', 'stage_id', 'stage_order_nr',
                      'status', 'title', 'undone_activities_count', 'update_time', 'user_id', 'value', 'visible_to',
-                     'weighted_value', 'won_time']
+                     'weighted_value', 'won_time', 'group_id', 'group_name', 'renewal_type']


### PR DESCRIPTION
# Description of change
TDL-18854: Add missing fields
- Added fields `group_id`, `group_name` and `renewal_type` in the Deals Stream.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
