### PR TITLE
TDL-18852: Add missing tap tester tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -55,7 +55,7 @@ class PipedriveBaseTest(unittest.TestCase):
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         return_value = {
-            'start_date' : "2021-05-03T09:44:26Z"
+            'start_date' : "2021-05-03T00:00:00Z"
         }
         if original:
             return return_value

--- a/tests/base.py
+++ b/tests/base.py
@@ -35,7 +35,9 @@ class PipedriveBaseTest(unittest.TestCase):
     DATETIME_FMT = {
         "%Y-%m-%dT%H:%M:%SZ",
         "%Y-%m-%d %H:%M:%S",
-        "%Y-%m-%dT%H:%M:%S.000000Z"
+        "%Y-%m-%dT%H:%M:%S.000000Z",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S.%f%z"
     }
 
     @staticmethod
@@ -53,7 +55,7 @@ class PipedriveBaseTest(unittest.TestCase):
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         return_value = {
-            'start_date' : "2021-04-29T00:00:00Z"
+            'start_date' : "2021-05-03T09:44:26Z"
         }
         if original:
             return return_value

--- a/tests/test_pipedrive_all_fields.py
+++ b/tests/test_pipedrive_all_fields.py
@@ -6,6 +6,29 @@ class PipedriveAllFields(PipedriveBaseTest):
 
     """Ensure running the tap with all streams and fields selected results in the replication of all fields."""
 
+    # Custom fields, not able to generate data for these fields.
+    fields_to_remove = {
+        "organizations": {
+            "timeline_last_activity_time",
+            "timeline_last_activity_time_by_owner",
+            "reference_activities_count",
+        },
+        "persons": {
+            "timeline_last_activity_time",
+            "timeline_last_activity_time_by_owner",
+            "reference_activities_count",
+        },
+        "files": {"email_message_id", "note_id"},
+        "users": {"activated"},
+        "deals": {
+            "product_amount",
+            "pipeline",
+            "reference_activities_count",
+            "product_quantity",
+        },
+        "products": {"unit_prices", "price"},
+    }
+
     def name(self):
         return "tap_tester_pipedrive_all_fields"
 
@@ -14,7 +37,7 @@ class PipedriveAllFields(PipedriveBaseTest):
         """
         Assert given conditions:
         • verify no unexpected streams are replicated
-        • Verify that more than just the automatic fields are replicated for each stream. 
+        • Verify that more than just the automatic fields are replicated for each stream.
         • Verify all fields for each streams are replicated
         """
 
@@ -53,7 +76,7 @@ class PipedriveAllFields(PipedriveBaseTest):
 
         # verify no unexpected streams are replicated
         synced_streams_names = set(stream_to_record_count.keys())
-        self.assertSetEqual(expected_streams,synced_streams_names)
+        self.assertSetEqual(expected_streams, synced_streams_names)
 
         for stream in expected_streams:
             with self.subTest(stream=stream):
@@ -75,6 +98,11 @@ class PipedriveAllFields(PipedriveBaseTest):
                         )
 
                 # verify all fields for each stream are replicated
+                # remove some fields as data cannot be generated / retrieved
+                fields = self.fields_to_remove.get(stream) or []
+                for field in fields:
+                    expected_all_keys.remove(field)
+
                 self.assertSetEqual(
                     expected_all_keys,
                     actual_all_keys,

--- a/tests/test_pipedrive_all_fields.py
+++ b/tests/test_pipedrive_all_fields.py
@@ -1,0 +1,82 @@
+from tap_tester import connections, menagerie, runner
+from base import PipedriveBaseTest
+
+
+class PipedriveAllFields(PipedriveBaseTest):
+
+    """Ensure running the tap with all streams and fields selected results in the replication of all fields."""
+
+    def name(self):
+        return "tap_tester_pipedrive_all_fields"
+
+    def test_all_fields_run(self):
+
+        """
+        Assert given conditions:
+        • verify no unexpected streams are replicated
+        • Verify that more than just the automatic fields are replicated for each stream. 
+        • Verify all fields for each streams are replicated
+        """
+
+        # Streams to verify all fields tests
+        expected_streams = self.expected_streams()
+
+        expected_automatic_fields = self.expected_automatic_fields()
+        conn_id = connections.ensure_connection(self)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs_all_fields = [catalog for catalog in found_catalogs
+                            if catalog.get("tap_stream_id") in expected_streams]
+
+        # perform table and field selections
+        self.perform_and_verify_table_and_field_selection(conn_id, test_catalogs_all_fields)
+
+        # Grab metadata after performing table and field selection to set expections
+        # used for asserting all fields are replicated
+        stream_to_catalog_fields = dict()
+        for catalog in test_catalogs_all_fields:
+            stream_id, stream_name = catalog['stream_id'], catalog['stream_name']
+            catalog_entry = menagerie.get_annotated_schema(conn_id, stream_id)
+            fields_from_field_level_md = [metadata["breadcrumb"][1]
+                                        for metadata in catalog_entry["metadata"]
+                                        if metadata["breadcrumb"] != []]
+            stream_to_catalog_fields[stream_name] = set(fields_from_field_level_md)
+
+        # run sync mode
+        stream_to_record_count = self.run_and_verify_sync(conn_id)
+
+        # get records from target output
+        synced_recs = runner.get_records_from_target_output()
+
+        # verify no unexpected streams are replicated
+        synced_streams_names = set(stream_to_record_count.keys())
+        self.assertSetEqual(expected_streams,synced_streams_names)
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values for stream
+                expected_all_keys = stream_to_catalog_fields[stream]
+                expected_automatic_keys = expected_automatic_fields[stream]
+
+                # Verify that more than just the automatic fields are replicated for each stream.
+                self.assertTrue(expected_automatic_keys.issubset(
+                    expected_all_keys), msg='{} is not in "expected_all_keys"'.format(expected_automatic_keys-expected_all_keys))
+
+                # actual values
+                actual_all_keys = set()
+                for message in synced_recs.get(stream).get("messages"):
+                    if message["action"] == "upsert":
+                        actual_all_keys = actual_all_keys.union(
+                            set(message["data"].keys())
+                        )
+
+                # verify all fields for each stream are replicated
+                self.assertSetEqual(
+                    expected_all_keys,
+                    actual_all_keys,
+                    msg=f"Expected keys and actual keys set does not match for the {stream} stream",
+                )

--- a/tests/test_pipedrive_automatic_fields.py
+++ b/tests/test_pipedrive_automatic_fields.py
@@ -1,0 +1,55 @@
+from tap_tester import runner, connections
+from base import PipedriveBaseTest
+
+class PipedriveAutomaticFieldsTest(PipedriveBaseTest):
+
+    def name(self):
+        return "tap_tester_pipedrive_automatic_fields_test"
+
+    def test_run(self):
+        """
+        Testing that all the automatic fields are replicated despite de-selecting them
+        - Verify that only the automatic fields are sent to the target.
+        - Verify that all replicated records have unique primary key values.
+        """
+        conn_id = connections.ensure_connection(self)
+        expected_streams = self.expected_streams()
+
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs = [catalog for catalog in found_catalogs
+                                      if catalog.get('stream_name') in expected_streams]
+
+        # Select all streams and no fields within streams
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, test_catalogs, select_all_fields=False)
+
+        # run sync
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        synced_records = runner.get_records_from_target_output()
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_primary_keys = self.expected_primary_keys()[stream]
+                expected_keys = expected_primary_keys | self.expected_replication_keys()[stream]
+
+                # collect actual values
+                messages = synced_records.get(stream)
+                record_messages_keys = [set(row['data'].keys()) for row in messages['messages']]
+
+                # check if the stream has collected some records
+                self.assertGreater(record_count_by_stream.get(stream, 0), 0)
+
+                # Verify that only the automatic fields are sent to the target
+                for actual_keys in record_messages_keys:
+                    self.assertSetEqual(expected_keys, actual_keys)
+
+                # Verify we did not duplicate any records across pages
+                records_pks_list = [tuple([message.get('data').get(primary_key) for primary_key in expected_primary_keys])
+                                           for message in messages.get('messages')]
+                self.assertCountEqual(records_pks_list, set(records_pks_list),
+                                      msg="We have duplicate records for {}".format(stream))

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -88,17 +88,13 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
                     # collect information specific to incremental streams from syncs 1 & 2
                     replication_key = list(expected_replication_keys[stream])[0] #Key in which state has been saved in state file
                     record_replication_key = list(expected_replication_keys[stream])[0]
-                    print(f'>>>>>>>>>>> {replication_key} {record_replication_key}')
-                    print(f'>>>>>>>>>>>1 {first_bookmark_key_value} {second_bookmark_key_value}')
 
                     first_bookmark_value = first_bookmark_key_value.get(replication_key)
                     second_bookmark_value = second_bookmark_key_value.get(replication_key)
-                    print(f'>>>>>>>>>>>2 {first_bookmark_value} {second_bookmark_value}')
                     
                     first_bookmark_value_ts = self.dt_to_ts(first_bookmark_value)
                     
                     second_bookmark_value_ts = self.dt_to_ts(second_bookmark_value)
-                    print(f'>>>>>>>>>>>3 {first_bookmark_value_ts} {second_bookmark_value_ts}')
                     
                     simulated_bookmark_value = self.dt_to_ts(new_state['bookmarks'][stream][replication_key])
 
@@ -109,10 +105,10 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
                     self.assertIsNotNone(second_bookmark_key_value)
                     self.assertIsNotNone(second_bookmark_value)
 
-                    # # Verify the second sync bookmark is Equal to the first sync bookmark
-                    # # assumes no changes to data during test
-                    # self.assertEqual(second_bookmark_value,
-                    #                  first_bookmark_value)
+                    # Verify the second sync bookmark is Equal to the first sync bookmark
+                    # assumes no changes to data during test
+                    self.assertEqual(second_bookmark_value,
+                                     first_bookmark_value)
                     
                     for record in first_sync_messages:
 

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -1,0 +1,164 @@
+import copy
+import os
+from dateutil.parser import parse
+from base import PipedriveBaseTest
+from tap_tester import runner, connections, menagerie
+
+class PipedriveBookmarksTest(PipedriveBaseTest):
+
+    def name(self):
+        return "tap_tester_pipedrive_bookmarks_test"
+
+    def test_run(self):
+        """
+        Testing that the bookmarking for the tap works as expected
+        - Verify for each incremental stream you can do a sync which records bookmarks
+        - Verify that a bookmark doesn't exist for full table streams.
+        - Verify the bookmark is the max value sent to the target for the a given replication key.
+        - Verify 2nd sync respects the bookmark
+        - All data of the 2nd sync is >= the bookmark from the first sync
+        - The number of records in the 2nd sync is less then the first
+        """
+        
+        conn_id = connections.ensure_connection(self)
+        runner.run_check_mode(self, conn_id)
+
+        expected_streams = self.expected_streams()
+        expected_replication_keys = self.expected_replication_keys()
+        expected_replication_methods = self.expected_replication_method()
+
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        catalog_entries = [catalog for catalog in found_catalogs
+                            if catalog.get('tap_stream_id') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, found_catalogs)
+
+        # Run a sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        ### Update State
+        ##########################################################################
+        new_state = {'bookmarks': dict()}
+        simulated_states = {"notes": {"update_time": "2021-05-06T09:49:19+00:00"}, "activities": {"update_time": "2021-05-05T06:15:46+00:00"}, "deals": {"update_time": "2021-05-10T07:44:45+00:00"}, "files": {"update_time": "2021-05-05T06:14:31+00:00"}, "organizations": {"update_time": "2021-05-06T09:51:40+00:00"}, "persons": {"update_time": "2021-05-07T10:40:33+00:00"}, "products": {"update_time": "2021-05-05T06:17:18+00:00"}, "dealflow": {"log_time": "2021-05-07T10:40:33+00:00"}}
+        # setting 'second_start_date' as bookmark for running 2nd sync
+        for stream, updated_state in simulated_states.items():
+            new_state['bookmarks'][stream] = updated_state
+
+        # Set state for next sync
+        menagerie.set_state(conn_id, new_state)
+
+        ##########################################################################
+        ### Second Sync
+        ##########################################################################
+
+        # Run a sync job using orchestrator
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmarks = menagerie.get_state(conn_id)
+
+        for stream in expected_streams:            
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_replication_method = expected_replication_methods[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+                first_sync_messages = [record.get('data') for record in
+                                       first_sync_records.get(
+                                           stream, {}).get('messages', [])
+                                       if record.get('action') == 'upsert']
+                second_sync_messages = [record.get('data') for record in
+                                        second_sync_records.get(
+                                            stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert']
+                first_bookmark_key_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                second_bookmark_key_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                
+
+                if expected_replication_method == self.INCREMENTAL:
+
+                    # collect information specific to incremental streams from syncs 1 & 2
+                    replication_key = list(expected_replication_keys[stream])[0] #Key in which state has been saved in state file
+                    record_replication_key = list(expected_replication_keys[stream])[0]
+                    print(f'>>>>>>>>>>> {replication_key} {record_replication_key}')
+                    print(f'>>>>>>>>>>>1 {first_bookmark_key_value} {second_bookmark_key_value}')
+
+                    first_bookmark_value = first_bookmark_key_value.get(replication_key)
+                    second_bookmark_value = second_bookmark_key_value.get(replication_key)
+                    print(f'>>>>>>>>>>>2 {first_bookmark_value} {second_bookmark_value}')
+                    
+                    first_bookmark_value_ts = self.dt_to_ts(first_bookmark_value)
+                    
+                    second_bookmark_value_ts = self.dt_to_ts(second_bookmark_value)
+                    print(f'>>>>>>>>>>>3 {first_bookmark_value_ts} {second_bookmark_value_ts}')
+                    
+                    simulated_bookmark_value = self.dt_to_ts(new_state['bookmarks'][stream][replication_key])
+
+                    # Verify the first sync sets a bookmark of the expected form
+                    self.assertIsNotNone(first_bookmark_key_value)
+                    self.assertIsNotNone(first_bookmark_value)
+                    
+                    self.assertIsNotNone(second_bookmark_key_value)
+                    self.assertIsNotNone(second_bookmark_value)
+
+                    # # Verify the second sync bookmark is Equal to the first sync bookmark
+                    # # assumes no changes to data during test
+                    # self.assertEqual(second_bookmark_value,
+                    #                  first_bookmark_value)
+                    
+                    for record in first_sync_messages:
+
+                        # Verify the first sync bookmark value is the max replication key value for a given stream
+                        replication_key_value = record.get(record_replication_key)
+                        replication_key_value_ts = self.dt_to_ts(replication_key_value)
+                        self.assertLessEqual(
+                            replication_key_value_ts, first_bookmark_value_ts,
+                            msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                        )
+
+                    for record in second_sync_messages:
+                        # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
+                        replication_key_value = record.get(record_replication_key)
+                        replication_key_value_ts = self.dt_to_ts(replication_key_value)
+                        self.assertGreaterEqual(replication_key_value_ts, simulated_bookmark_value,
+                                                msg="Second sync records do not respect the previous bookmark.")
+
+                        # Verify the second sync bookmark value is the max replication key value for a given stream
+                        self.assertLessEqual(
+                            replication_key_value_ts, second_bookmark_value_ts,
+                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                        )
+
+                    # verify that you get less data the 2nd time around
+                    self.assertLess(
+                        second_sync_count,
+                        first_sync_count,
+                        msg="second sync didn't have less records, bookmark usage not verified")
+
+                elif expected_replication_method == self.FULL_TABLE:
+
+                    # Verify the syncs do not set a bookmark for full table streams
+                    self.assertIsNone(first_bookmark_key_value)
+                    self.assertIsNone(second_bookmark_key_value)
+
+                    # Verify the number of records in the second sync is the same as the first
+                    self.assertEqual(second_sync_count, first_sync_count)
+
+                else:
+
+                    raise NotImplementedError(
+                        "INVALID EXPECTATIONS\t\tSTREAM: {} REPLICATION_METHOD: {}".format(
+                            stream, expected_replication_method)
+                    )
+
+                # Verify at least 1 record was replicated in the second sync
+                self.assertGreater(
+                    second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -107,8 +107,10 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
 
                     # Verify the second sync bookmark is Equal to the first sync bookmark
                     # assumes no changes to data during test
-                    self.assertEqual(second_bookmark_value,
-                                     first_bookmark_value)
+                    # The dealflow stream is writing bookmark as a 'current_time-3_hours' so 1st and 2nd bookmark will be different
+                    if stream != "dealflow":
+                        self.assertEqual(second_bookmark_value,
+                                         first_bookmark_value)
                     
                     for record in first_sync_messages:
 

--- a/tests/test_pipedrive_discovery.py
+++ b/tests/test_pipedrive_discovery.py
@@ -17,7 +17,7 @@ class PipedriveDiscovery(PipedriveBaseTest):
         • Verify number of actual streams discovered match expected
         • Verify the stream names discovered were what we expect
         • Verify stream names follow naming convention
-          streams sh4ould only have lowercase alphas and underscores
+          streams should only have lowercase alphas and underscores
         • verify there is only 1 top level breadcrumb
         • verify replication key(s)
         • verify primary key(s)

--- a/tests/test_pipedrive_discovery.py
+++ b/tests/test_pipedrive_discovery.py
@@ -26,6 +26,7 @@ class PipedriveDiscovery(PipedriveBaseTest):
         • verify that primary, replication and foreign keys
           are given the inclusion of automatic.
         • verify that all other fields have inclusion of available metadata.
+        • Verify there are no duplicate/conflicting metadata entries.
         """
         streams_to_test = self.expected_streams()
 
@@ -111,3 +112,11 @@ class PipedriveDiscovery(PipedriveBaseTest):
                          and item.get("breadcrumb", ["properties", None])[1]
                          not in actual_automatic_fields}),
                     msg="Not all non key properties are set to available in metadata")
+
+                actual_fields = []
+                for md_entry in metadata:
+                    if md_entry['breadcrumb'] != []:
+                        actual_fields.append(md_entry['breadcrumb'][1])
+
+                # Verify there are no duplicate metadata entries
+                self.assertEqual(len(actual_fields), len(set(actual_fields)), msg = "duplicates in the metadata entries retrieved")


### PR DESCRIPTION
# Description of change
TDL-18852: Add missing tap-tester tests

- Added all_field, automatic_fields, and bookmark test cases. Also updated discovery test case to add missing assertions.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
