### PR TITLE
TDL-19176: Add backoff/retry for 5xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.3.0
+  * Adds backoff/retry for Http5xx errors [#115](https://github.com/singer-io/tap-pipedrive/pull/115)
+
 # 1.2.0
   * Adds `deal_fields` stream [#134](https://github.com/singer-io/tap-pipedrive/pull/134)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 1.3.0
+# 1.2.1
   * Adds backoff/retry for Http5xx errors [#115](https://github.com/singer-io/tap-pipedrive/pull/115)
 
 # 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.2.0",
+      version="1.3.0",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.3.0",
+      version="1.2.1",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/exceptions.py
+++ b/tap_pipedrive/exceptions.py
@@ -6,6 +6,10 @@ class PipedriveError(Exception):
         self.message = message
         self.response = response
 
+# Reference: https://pipedrive.readme.io/docs/core-api-concepts-http-status-codes
+class Pipedrive5xxError(PipedriveError):
+    pass
+
 class PipedriveNotFoundError(PipedriveError):
     pass
 
@@ -36,11 +40,11 @@ class PipedriveTooManyRequestsError(PipedriveError):
 class PipedriveTooManyRequestsInSecondError(PipedriveError):
     pass
 
-class PipedriveInternalServiceError(PipedriveError):
+class PipedriveInternalServiceError(Pipedrive5xxError): # 500 error
     pass
 
-class PipedriveNotImplementedError(PipedriveError):
+class PipedriveNotImplementedError(Pipedrive5xxError): # 501 error
     pass
 
-class PipedriveServiceUnavailableError(PipedriveError):
+class PipedriveServiceUnavailableError(Pipedrive5xxError): # 503 error
     pass

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -300,8 +300,8 @@ class PipedriveTap(object):
         params = stream.update_request_params(params)
         return self.execute_request(stream.endpoint, params=params)
 
-    @backoff.on_exception(backoff.expo, (Timeout, Pipedrive5xxError, ConnectionError, PipedriveNull200Error), max_tries = 5, factor = 2)
-    @backoff.on_exception(backoff.expo, (PipedriveInternalServiceError, simplejson.scanner.JSONDecodeError), max_tries = 3)
+    @backoff.on_exception(backoff.expo, (Timeout, Pipedrive5xxError, ConnectionError, PipedriveNull200Error), max_tries=5, factor=2)
+    @backoff.on_exception(backoff.expo, simplejson.scanner.JSONDecodeError, max_tries=3)
     @backoff.on_exception(retry_after_wait_gen, (PipedriveTooManyRequestsInSecondError, PipedriveBadRequestError), giveup=is_not_status_code_fn([429]), jitter=None, max_tries=3)
     def execute_request(self, endpoint, params=None):
         headers = {

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -13,7 +13,7 @@ from singer.catalog import Catalog, CatalogEntry, Schema
 from .config import BASE_URL, CONFIG_DEFAULTS
 from .exceptions import (PipedriveError, PipedriveNotFoundError, PipedriveBadRequestError, PipedriveUnauthorizedError, PipedrivePaymentRequiredError, 
                         PipedriveForbiddenError, PipedriveGoneError, PipedriveUnsupportedMediaError, PipedriveUnprocessableEntityError, PipedriveTooManyRequestsError, 
-                        PipedriveTooManyRequestsInSecondError,PipedriveInternalServiceError, PipedriveNotImplementedError, PipedriveServiceUnavailableError)
+                        PipedriveTooManyRequestsInSecondError,PipedriveInternalServiceError, PipedriveNotImplementedError, PipedriveServiceUnavailableError, Pipedrive5xxError)
 from .streams import (CurrenciesStream, ActivityTypesStream, FiltersStream, StagesStream, PipelinesStream,
                       RecentNotesStream, RecentUsersStream, RecentActivitiesStream, RecentDealsStream,
                       RecentFilesStream, RecentOrganizationsStream, RecentPersonsStream, RecentProductsStream,
@@ -292,8 +292,8 @@ class PipedriveTap(object):
         params = stream.update_request_params(params)
         return self.execute_request(stream.endpoint, params=params)
 
-    @backoff.on_exception(backoff.expo, (Timeout, ConnectionError), max_tries = 5, factor = 2)
-    @backoff.on_exception(backoff.expo, (PipedriveInternalServiceError, simplejson.scanner.JSONDecodeError), max_tries = 3)
+    @backoff.on_exception(backoff.expo, (Timeout, Pipedrive5xxError, ConnectionError), max_tries = 5, factor = 2)
+    @backoff.on_exception(backoff.expo, (simplejson.scanner.JSONDecodeError), max_tries = 3)
     @backoff.on_exception(retry_after_wait_gen, PipedriveTooManyRequestsInSecondError, giveup=is_not_status_code_fn([429]), jitter=None, max_tries=3)
     def execute_request(self, endpoint, params=None):
         headers = {
@@ -375,6 +375,13 @@ def raise_for_error(response):
                 message = "HTTP-error-code: {}, Error: {}".format(error_code, message_text)
 
             exc = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", PipedriveError)
+
+            # Pipedrive doc has only mentioned 500, 501 and 503 errors but while executing
+            # we encounter errors apart form the doc like 524 error. So handling the same
+            #   Doc: https://pipedrive.readme.io/docs/core-api-concepts-http-status-codes
+            if error_code > 500 and error_code not in ERROR_CODE_EXCEPTION_MAPPING.keys():
+                exc = Pipedrive5xxError
+
             raise exc(message, response) from None
 
         except (ValueError, TypeError):

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -125,9 +125,6 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
 
                         # Verify the first sync bookmark value is the max replication key value for a given stream
                         replication_key_value = record.get(replication_key)
-                        if stream == "deal_fields" and not replication_key_value:
-                            # add_time as replication_key_value if update_time is None for deal_fields
-                            replication_key_value = record.get("add_time")
                         replication_key_value_ts = self.dt_to_ts(replication_key_value, self.REPLICATION_KEY_FORMAT)
                         self.assertLessEqual(
                             replication_key_value_ts, first_bookmark_value_ts,

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -27,289 +27,216 @@ def get_mock_http_response(status_code, contents):
     response._content = contents.encode()
     return response
 
+@mock.patch('time.sleep')
 @mock.patch('requests.get')
 class TestExecuteRequestExceptionHandling(unittest.TestCase):
     """
     Test cases to verify if the exceptions are handled as expected while communicating with Pipedrive Environment 
     """
 
-    def test_json_decode_successfull_with_200(self, mocked_jsondecode_successful_request):
+    # config
+    config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
+    endpoint = "xyz"
+
+    # pipedrive object
+    pipedrive_tap = _tap.PipedriveTap(config, {})
+
+    def test_json_decode_successfull_with_200(self, mocked_jsondecode_successful_request, mocked_sleep):
         json_decode_str = '{"success": true, "data" : []}'
         mocked_jsondecode_successful_request.return_value = get_mock_http_response(200, json_decode_str)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
-
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except simplejson.scanner.JSONDecodeError:
-            pass
+        self.pipedrive_tap.execute_request(self.endpoint)
 
         self.assertEqual(mocked_jsondecode_successful_request.call_count, 1)
 
-    def test_json_decode_exception(self, mocked_jsondecode_failing_request):
+    def test_json_decode_exception(self, mocked_jsondecode_failing_request, mocked_sleep):
         json_decode_error_str = '{\Currency\': \'value\'}'
         mocked_jsondecode_failing_request.return_value = get_mock_http_response(200, json_decode_error_str)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
-
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except simplejson.scanner.JSONDecodeError:
-            pass
+        with self.assertRaises(simplejson.scanner.JSONDecodeError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
         self.assertEqual(mocked_jsondecode_failing_request.call_count, 3)
 
-    def test_badrequest_400_error(self, mocked_request):
+    def test_badrequest_400_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(400, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveBadRequestError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveBadRequestError as e:
-            expected_error_message = "HTTP-error-code: 400, Error: Request is missing or has a bad parameter."
-
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        expected_error_message = "HTTP-error-code: 400, Error: Request is missing or has a bad parameter."
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_unauthorized_401_error(self, mocked_request):
+    def test_unauthorized_401_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(401, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveUnauthorizedError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveUnauthorizedError as e:
-            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+        expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_paymentrequired_402_error(self, mocked_request):
+    def test_paymentrequired_402_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(402, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedrivePaymentRequiredError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedrivePaymentRequiredError as e:
-            expected_error_message = "HTTP-error-code: 402, Error: Company account is not open (possible reason: trial expired, payment details not entered)."
+        expected_error_message = "HTTP-error-code: 402, Error: Company account is not open (possible reason: trial expired, payment details not entered)."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_forbidden_403_error(self, mocked_request):
+    def test_forbidden_403_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(403, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveForbiddenError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveForbiddenError as e:
-            expected_error_message = "HTTP-error-code: 403, Error: Invalid authorization credentials or permissions."
+        expected_error_message = "HTTP-error-code: 403, Error: Invalid authorization credentials or permissions."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_notfound_404_error(self, mocked_request):
+    def test_notfound_404_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(404, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveNotFoundError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveNotFoundError as e:
-            expected_error_message = "HTTP-error-code: 404, Error: The requested resource does not exist."
+        expected_error_message = "HTTP-error-code: 404, Error: The requested resource does not exist."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_gone_410_error(self, mocked_request):
+    def test_gone_410_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(410, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveGoneError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveGoneError as e:
-            expected_error_message = "HTTP-error-code: 410, Error: The old resource is permanently unavailable."
+        expected_error_message = "HTTP-error-code: 410, Error: The old resource is permanently unavailable."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_unsupported_media_type_415_error(self, mocked_request):
+    def test_unsupported_media_type_415_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(415, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveUnsupportedMediaError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveUnsupportedMediaError as e:
-            expected_error_message = "HTTP-error-code: 415, Error: The feature is not enabled."
+        expected_error_message = "HTTP-error-code: 415, Error: The feature is not enabled."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_unproceesable_entity_422_error(self, mocked_request):
+    def test_unproceesable_entity_422_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(422, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveUnprocessableEntityError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveUnprocessableEntityError as e:
-            expected_error_message = "HTTP-error-code: 422, Error: Webhook limit reached."
+        expected_error_message = "HTTP-error-code: 422, Error: Webhook limit reached."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_rate_limit_in_seconds_429_error(self, mocked_request):
+    def test_rate_limit_in_seconds_429_error(self, mocked_request, mocked_sleep):
         headers = {"X-RateLimit-Reset": 2, "X-RateLimit-Remaining":0}
         mocked_request.return_value = Mockresponse(429, {}, headers=headers, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveTooManyRequestsInSecondError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveTooManyRequestsInSecondError as e:
-            expected_error_message = "HTTP-error-code: 429, Error: Rate limit has been exceeded. Please retry after 2 seconds."
+        expected_error_message = "HTTP-error-code: 429, Error: Rate limit has been exceeded. Please retry after 2 seconds."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 3)
 
-    def test_rate_limit_in_day_429_error(self, mocked_request):
+    def test_rate_limit_in_day_429_error(self, mocked_request, mocked_sleep):
         headers = {"X-RateLimit-Reset": 200, "X-RateLimit-Remaining":10}
         mocked_request.return_value = Mockresponse(429, {}, headers=headers, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveTooManyRequestsError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveTooManyRequestsError as e:
-            expected_error_message = "HTTP-error-code: 429, Error: Daily Rate limit has been exceeded. Please retry after 200 seconds."
+        expected_error_message = "HTTP-error-code: 429, Error: Daily Rate limit has been exceeded. Please retry after 200 seconds."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
-    def test_internalservererror_500_error(self, mocked_request):
+    def test_internalservererror_500_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(500, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveInternalServiceError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveInternalServiceError as e:
-            expected_error_message = "HTTP-error-code: 500, Error: Internal Service Error from PipeDrive."
+        expected_error_message = "HTTP-error-code: 500, Error: Internal Service Error from PipeDrive."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
-        self.assertEqual(mocked_request.call_count, 3)
+        self.assertEqual(mocked_request.call_count, 5)
 
-    def test_not_implemented_501_error(self, mocked_request):
+    def test_not_implemented_501_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(501, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveNotImplementedError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveNotImplementedError as e:
-            expected_error_message = "HTTP-error-code: 501, Error: Functionality does not exist."
+        expected_error_message = "HTTP-error-code: 501, Error: Functionality does not exist."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
-        self.assertEqual(mocked_request.call_count, 1)
+        self.assertEqual(mocked_request.call_count, 5)
 
-    def test_service_unavailable_503_error(self, mocked_request):
+    def test_service_unavailable_503_error(self, mocked_request, mocked_sleep):
         mocked_request.return_value = Mockresponse(503, {}, raise_error=True)
 
-        config = {"start_date":"2017-01-01T00:00:00Z","api_token":"abc"}
-        state = {}
-        endpoint = 'xyz'
+        with self.assertRaises(_tap.PipedriveServiceUnavailableError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
 
-        pipedrive_tap = _tap.PipedriveTap(config, state)
-        try:
-            pipedrive_tap.execute_request(endpoint)
-        except _tap.PipedriveServiceUnavailableError as e:
-            expected_error_message = "HTTP-error-code: 503, Error: Schedule maintenance on Pipedrive's end."
+        expected_error_message = "HTTP-error-code: 503, Error: Schedule maintenance on Pipedrive's end."
 
-            # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
-            pass
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
 
-        self.assertEqual(mocked_request.call_count, 1)
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_5XX_errors_other_than_doc(self, mocked_request, mocked_sleep):
+        mocked_request.return_value = Mockresponse(524, {}, raise_error=True)
+
+        with self.assertRaises(_tap.Pipedrive5xxError) as e:
+            self.pipedrive_tap.execute_request(self.endpoint)
+
+        expected_error_message = "HTTP-error-code: 524, Error: Unknown Error"
+
+        # Verifying the message formed for the custom exception
+        self.assertEquals(str(e.exception), expected_error_message)
+
+        self.assertEqual(mocked_request.call_count, 5)


### PR DESCRIPTION
# Description of change
TDL-19176: Add backoff/retry for 5xx errors
- Added backoff for 501 and 503 errors from the [API doc](https://pipedrive.readme.io/docs/core-api-concepts-http-status-codes)
- Also handled other 5XX errors not mentioned in the doc.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
