### PR TITLE
Handle new structure for `users` rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1 1.3
+  * Access `users` data using new structure, rather than indexing into a single `list` [#119](https://github.com/singer-io/tap-pipedrive/pull/119)
+
 ## 1 1.2
   * Adding missing fields [#111](https://github.com/singer-io/tap-pipedrive/pull/111)
   * Add missing tap-tester cases [#113](https://github.com/singer-io/tap-pipedrive/pull/113)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.1.2",
+      version="1.1.3",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/streams/recents/users.py
+++ b/tap_pipedrive/streams/recents/users.py
@@ -10,4 +10,10 @@ class RecentUsersStream(RecentsStream):
     replication_method = 'FULL_TABLE'
 
     def process_row(self, row):
-        return row['data'][0]
+        # NB> Temporary split here in response to unintended change made with this changelog
+        # - https://developers.pipedrive.com/changelog/post/improvements-to-permissionsets-api-and-users-api
+        # - This used to be a list, but turned into an object with this changelog entry's effective date.
+        if isinstance(row['data'], dict):
+            return row['data']
+        else:
+            return row['data'][0]


### PR DESCRIPTION
# Description of change
This PR is a reaction to an undocumented change that went out with this [Changelog Entry to the Users API](https://developers.pipedrive.com/changelog/post/improvements-to-permissionsets-api-and-users-api).

It appears that there was a cleanliness change to change the structure from a single-element list to a JSON object like the other streams.

Since this was an undocumented and (likely) unintentional change, this PR accepts both formats in case of a rollback to continue functionality.

# Manual QA steps
 - Ran through this, got the failure, made this change, and the extraction succeeded
 
# Risks
 - Low, it is currently 100% broken on this line, and the fallback should maintain compatibility in the event of a reversion on Pipedrive's end.
 
# Rollback steps
 - revert this branch, bump patch version, re-release
