### PR TITLE
TDL-21766 Update schema for deal_products to allow null product_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.5
+  * Allows a deal_products record to contain a null `product_id` value per Pipedrive's [hard-deletion policy](https://developers.pipedrive.com/changelog/post/permanent-deletion-logic-for-6-core-entities) [#126](https://github.com/singer-io/tap-pipedrive/pull/126)
+
 ## 1.1.4
   * Fixed `NoneType` and Transformstion issues for Anamolous Failed Jobs [#120](https://github.com/singer-io/tap-pipedrive/pull/120)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.1.4",
+      version="1.1.5",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/schemas/deal_products.json
+++ b/tap_pipedrive/schemas/deal_products.json
@@ -13,6 +13,7 @@
     },
     "product_id": {
       "type": [
+        "null",
         "integer"
       ]
     },


### PR DESCRIPTION
# Description of change
Allows a deal_products record to contain a null `product_id` value per Pipedrive's [hard-deletion policy](https://developers.pipedrive.com/changelog/post/permanent-deletion-logic-for-6-core-entities)

# Manual QA steps
 - Tested with customer connection; Validated intention with Pipedrive support / engineering.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
