### PR TITLE
Remove Pagination State Write because of child streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.7
+  * Reverts state change from 1.1.6 due to child streams using parent stream pagination [#130](https://github.com/singer-io/tap-pipedrive/pull/130)
+
 ## 1.1.6
   * Makes several fields in `notes` nullable
   * Writes state during pagination for more efficient extraction

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.1.6",
+      version="1.1.7",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -278,7 +278,6 @@ class PipedriveTap(object):
                         if stream.write_record(row):
                             counter.increment()
                             stream.update_state(row)
-                    singer.write_state(self.state)
 
     def get_default_config(self):
         return CONFIG_DEFAULTS


### PR DESCRIPTION
# Description of change
Reverts state change from PR 128 because child streams should not store state at end of page and are not handled differently than parent streams.

# Manual QA steps
 - Run with local connection
 
# Risks
 - low; fixes recent bug
 
# Rollback steps
 - revert this branch
