### PR TITLE
Retry null requests for DealsFlow stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.8
+  * Retries requests with 200 status and null bodies for dealsflow stream [#131](https://github.com/singer-io/tap-pipedrive/pull/131)
+
 # 1.1.7
   * Reverts state change from 1.1.6 due to child streams using parent stream pagination [#130](https://github.com/singer-io/tap-pipedrive/pull/130)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.1.7",
+      version="1.1.8",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -328,15 +328,13 @@ class PipedriveTap(object):
             try:
                 # Verifying json is valid or not
                 response.json()
-                #return response
             except simplejson.scanner.JSONDecodeError as e:
                 raise e
             # Retry requests with null bodys and 200 status for dealsflow stream
             if response.json() is None and "flow" in response.url:
                 logger.info("Received null body with 200 status for url: %s, retrying", url)
                 raise PipedriveNull200Error
-            else:
-                return response
+            return response
         else:
             raise_for_error(response)
 

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -95,6 +95,11 @@ def retry_after_wait_gen():
         yield math.floor(float(sleep_time_str))
 
 
+class PipedriveNull200Error(Exception):
+    "Raised when pipedrive api returns a 200 with null body"
+    pass
+
+
 class PipedriveTap(object):
     streams = [
         CurrenciesStream(),
@@ -294,12 +299,13 @@ class PipedriveTap(object):
         params = stream.update_request_params(params)
         return self.execute_request(stream.endpoint, params=params)
 
-    @backoff.on_exception(backoff.expo, (Timeout, ConnectionError), max_tries = 5, factor = 2)
+    @backoff.on_exception(backoff.expo, (Timeout, ConnectionError, PipedriveNull200Error), max_tries = 5, factor = 2)
     @backoff.on_exception(backoff.expo, (PipedriveInternalServiceError, simplejson.scanner.JSONDecodeError), max_tries = 3)
     @backoff.on_exception(retry_after_wait_gen, (PipedriveTooManyRequestsInSecondError, PipedriveBadRequestError), giveup=is_not_status_code_fn([429]), jitter=None, max_tries=3)
     def execute_request(self, endpoint, params=None):
         headers = {
-            'User-Agent': self.config['user-agent']
+            'User-Agent': self.config['user-agent'],
+            'Accept-Encoding': 'application/json'
         }
         _params = {
             'api_token': self.config['api_token'],
@@ -322,9 +328,15 @@ class PipedriveTap(object):
             try:
                 # Verifying json is valid or not
                 response.json()
-                return response
+                #return response
             except simplejson.scanner.JSONDecodeError as e:
                 raise e
+            # Retry requests with null bodys and 200 status for dealsflow stream
+            if response.json() is None and "flow" in response.url:
+                logger.info("Received null body with 200 status for url: %s, retrying", url)
+                raise PipedriveNull200Error
+            else:
+                return response
         else:
             raise_for_error(response)
 

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -22,7 +22,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=300) # Expected timeout
 
@@ -41,7 +42,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=100.0) # Expected timeout
 
@@ -60,7 +62,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=100.5) # Expected timeout
 
@@ -79,7 +82,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=100.0) # Expected timeout
 
@@ -98,7 +102,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=300.0) # Expected timeout
 
@@ -117,7 +122,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=300.0) # Expected timeout
 
@@ -136,7 +142,8 @@ class TestRequestTimeoutValue(unittest.TestCase):
 
         # Verify requests.get is called with expected timeout
         mocked_request.assert_called_with('https://api.pipedrive.com/v1/xyz',
-                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)'},
+                                          headers={'User-Agent': 'tap-pipedrive (+support@stitchdata.com)',
+                                                   'Accept-Encoding': 'application/json'},
                                           params={'api_token': 'abc'},
                                           timeout=300.0) # Expected timeout
 


### PR DESCRIPTION
# Description of change

- Adds retries for dealflows requests that return a status of 200 but a null body. 
- Adds the `'Accept-Encoding': 'application/json'` header to all requests, which is advised in pipedrives docs: https://pipedrive.readme.io/docs/core-api-concepts-requests 

# Manual QA steps
 - applied the change as a pr-alpha to client in TDL-22119 and resolved the error they were receiving. 
 
# Risks
 - Adding a new header could possibly change things for other streams, but the tap expects data to be returned as json, so it would likely be for the better. 
 
# Rollback steps
 - revert this branch
