### PR TITLE
Fix datetime conversion and nonetype error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.3.1
+  * Fix Nonetype and datetime conversion error  [#146](https://github.com/singer-io/tap-pipedrive/pull/146)
+
 # 1.3.0
   * Upgrade api version to v2 below streams [#144](https://github.com/singer-io/tap-pipedrive/pull/144)
     * activities

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="1.3.0",
+      version="1.3.1",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -149,7 +149,7 @@ class RecentsStream(PipedriveV1IncrementalStream):
             return super().update_request_params(params)
         else:
             params.update({
-                'since_timestamp': datetime.strptime(self.initial_state, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d %H:%M:%S"),
+                'since_timestamp': datetime.strptime(self.initial_state, "%Y-%m-%dT%H:%M:%S%z").strftime("%Y-%m-%d %H:%M:%S"),
                 'items': self.items
             })
             self.endpoint = self.recent_endpoint

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -285,7 +285,8 @@ class PipedriveTap(object):
                             continue
 
                         # Flatten custom fields into the row
-                        row.update(row.get('custom_fields', {}))
+                        if 'custom_fields' in row and row['custom_fields'] is not None:
+                            row.update(row.get('custom_fields', {}))
                         transformed_row = transformer.transform(row, stream.get_schema(), stream_metadata)
                         if stream.write_record(transformed_row):
                             counter.increment()


### PR DESCRIPTION
# Description of change
- The existing connection bookmark was being written in the format 2025-07-09T13:30:07+00:00, while the expected format was %Y-%m-%dT%H:%M:%SZ. This mismatch caused the problem.
- Additionally, we identified that the API returns custom_fields with None values, whereas we expect a dictionary. To address this, we flattened the dictionary into the parent object.
%Y-%m-%d %H:%M:%S

Fixed both the issue as part of this PR.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
