### PR TITLE
Upgrade python version, increase test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
           command: |
             uv venv --python 3.12 /usr/local/share/virtualenvs/tap-pipedrive
             source /usr/local/share/virtualenvs/tap-pipedrive/bin/activate
-            uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
             uv pip install .[dev]
       - run:
           name: 'Unit Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.11 /usr/local/share/virtualenvs/tap-pipedrive
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-pipedrive
             source /usr/local/share/virtualenvs/tap-pipedrive/bin/activate
             uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
             uv pip install .[dev]

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(name="tap-pipedrive",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_pipedrive"],
       install_requires=[
-          "pendulum==3.1.0",
-          "requests==2.32.4",
-          "singer-python==6.1.1",
+          "pendulum==3.2.0",
+          "requests==2.33.1",
+          "singer-python==6.8.0",
       ],
       entry_points="""
           [console_scripts]

--- a/spike/seed_pipedrive.md
+++ b/spike/seed_pipedrive.md
@@ -1,0 +1,145 @@
+# Pipedrive Test Account — Data Seeding Guide
+
+This document describes which tap streams can be seeded via the script
+[`spike/seed_pipedrive.py`](seed_pipedrive.py), which cannot, and how to
+add data manually through the Pipedrive web UI.
+
+---
+
+## Running the Script
+
+```bash
+# From the tap-pipedrive root directory
+pip install requests
+python spike/seed_pipedrive.py --api-token <YOUR_API_TOKEN>
+
+# Or point at the existing config.json
+python spike/seed_pipedrive.py --api-token dummy --config config.json
+```
+
+The script is **idempotent**: it checks for existing objects by name before
+creating them, so re-running is safe.
+
+---
+
+## Streams Seeded via Script
+
+| Stream | Pipedrive Resource | API Endpoint | Notes |
+|---|---|---|---|
+| `pipelines` | Pipeline | `POST /v1/pipelines` | Creates "Stitch Test Pipeline" |
+| `stages` | Stage | `POST /v1/stages` | Creates 4 stages inside the test pipeline |
+| `organizations` | Organization | `POST /v1/organizations` | Creates 3 test organizations |
+| `persons` | Person | `POST /v1/persons` | Creates 3 persons linked to organizations |
+| `products` | Product | `POST /v1/products` | Creates 2 products with USD pricing |
+| `deals` | Deal | `POST /v1/deals` | Creates 4 deals (open + won) linked to persons/orgs/stages |
+| `dealflow` | Deal Stage-Change Events | `PUT /v1/deals/{id}` (stage move) | Moves deals between stages to generate `dealChange` events captured by this stream |
+| `deal_products` | Deal ↔ Product | `POST /v1/deals/{id}/products` | Attaches products to deals |
+| `activity_types` | Activity Type | `POST /v1/activityTypes` | Creates 2 custom activity types |
+| `activities` | Activity | `POST /v1/activities` | Creates 3 activities linked to deals and persons |
+| `notes` | Note | `POST /v1/notes` | Creates 3 notes linked to deals, persons, and orgs |
+| `filters` | Filter | `POST /v1/filters` | Creates 1 deal filter |
+| `deal_fields` | Custom Deal Field | `POST /v1/dealFields` | Creates 2 custom fields (numeric + enum) |
+| `files` | File | `POST /v1/files` (multipart) | Uploads a small text attachment linked to a deal |
+
+**Total: 14 of 16 streams seeded via script.**
+
+---
+
+## Streams That Cannot Be Seeded via Script
+
+### `currencies`
+
+**Reason:** Pipedrive does not expose a `POST /currencies` endpoint.
+The currencies list is system-managed. Only the account owner can enable
+additional currencies.
+
+**How to add via Web UI:**
+1. Log in to Pipedrive.
+2. Go to **Settings → Company Settings → Currencies**.
+3. Click **Add currency** and select any additional currency (e.g. EUR, GBP).
+4. Save. The tap will then pick up all enabled currencies on next sync.
+
+---
+
+### `users`
+
+**Reason:** Pipedrive does not allow creating user accounts via the API.
+Users must be invited through the web UI, and the API token holder must
+have **Admin** role to see other users.
+
+**How to add via Web UI:**
+1. Log in to Pipedrive as an **Admin** user.
+2. Go to **Settings → Manage Users → Users**.
+3. Click **Add User**, enter an email address (can be a test email alias
+   such as `stitch+test1@yourdomain.com`).
+4. Set role to **Regular User** and click **Send Invitation**.
+5. Once accepted, the user appears in the `users` stream on next sync.
+
+> **Note:** The `users` stream uses the `/recents` endpoint with
+> `items=user`. Even a single active user (the API token owner) will
+> produce at least one record; you do not strictly need extra users for
+> basic coverage.
+
+---
+
+## Stream Dependency Order
+
+The script seeds resources in the correct dependency order because some
+objects require others to exist first:
+
+```
+pipelines
+  └── stages
+        └── deals
+              ├── dealflow      (move deals between stages)
+              ├── deal_products (attach products to deals)
+              └── notes (linked to deal)
+
+organizations
+  └── persons
+        └── deals (linked to person + org)
+              └── activities (linked to deal + person)
+
+products  (standalone)
+activity_types  (standalone)
+filters  (standalone)
+deal_fields  (standalone)
+files  (attached to deal)
+```
+
+---
+
+## Verifying Data After Seeding
+
+Run discovery to confirm all streams are available:
+
+```bash
+tap-pipedrive --config config.json --discover > catalog.json
+```
+
+Select all streams and run a sync:
+
+```bash
+tap-pipedrive --config config.json --catalog catalog.json
+```
+
+You should see Singer `RECORD` messages for each of the 14 scriptable streams.
+For `currencies` and `users`, add them via the web UI steps above if records
+are missing.
+
+---
+
+## Re-seeding / Cleanup
+
+Because all objects are created with a "Stitch" prefix in their names,
+they are easy to find and delete manually:
+
+- Deals titled `Stitch Test Deal — *`
+- Pipeline named `Stitch Test Pipeline`
+- Persons with email `*@stitchtest.invalid`
+- Organizations starting with `Stitch`
+- Filters named `Stitch — *`
+- Deal fields named `Stitch *`
+- Files named `stitch_seed_attachment.txt`
+
+Alternatively delete and re-create the test account to start fresh.

--- a/spike/seed_pipedrive.md
+++ b/spike/seed_pipedrive.md
@@ -26,20 +26,20 @@ creating them, so re-running is safe.
 
 | Stream | Pipedrive Resource | API Endpoint | Notes |
 |---|---|---|---|
-| `pipelines` | Pipeline | `POST /v1/pipelines` | Creates "Stitch Test Pipeline" |
-| `stages` | Stage | `POST /v1/stages` | Creates 4 stages inside the test pipeline |
-| `organizations` | Organization | `POST /v1/organizations` | Creates 3 test organizations |
-| `persons` | Person | `POST /v1/persons` | Creates 3 persons linked to organizations |
-| `products` | Product | `POST /v1/products` | Creates 2 products with USD pricing |
-| `deals` | Deal | `POST /v1/deals` | Creates 4 deals (open + won) linked to persons/orgs/stages |
-| `dealflow` | Deal Stage-Change Events | `PUT /v1/deals/{id}` (stage move) | Moves deals between stages to generate `dealChange` events captured by this stream |
-| `deal_products` | Deal ↔ Product | `POST /v1/deals/{id}/products` | Attaches products to deals |
-| `activity_types` | Activity Type | `POST /v1/activityTypes` | Creates 2 custom activity types |
-| `activities` | Activity | `POST /v1/activities` | Creates 3 activities linked to deals and persons |
-| `notes` | Note | `POST /v1/notes` | Creates 3 notes linked to deals, persons, and orgs |
-| `filters` | Filter | `POST /v1/filters` | Creates 1 deal filter |
-| `deal_fields` | Custom Deal Field | `POST /v1/dealFields` | Creates 2 custom fields (numeric + enum) |
-| `files` | File | `POST /v1/files` (multipart) | Uploads a small text attachment linked to a deal |
+| `pipelines` | Pipeline | `POST /v1/pipelines` | Creates "Stitch Pipeline Alpha" and "Stitch Pipeline Beta" |
+| `stages` | Stage | `POST /v1/stages` | Creates the test stages used by the Alpha/Beta pipelines |
+| `organizations` | Organization | `POST /v1/organizations` | Creates approximately 110 test organizations per wave |
+| `persons` | Person | `POST /v1/persons` | Creates approximately 110 persons per wave, linked to organizations |
+| `products` | Product | `POST /v1/products` | Creates seeded test products with USD pricing |
+| `deals` | Deal | `POST /v1/deals` | Creates approximately 110 deals per wave, linked to persons, organizations, and stages |
+| `dealflow` | Deal Stage-Change Events | `PUT /v1/deals/{id}` (stage move) | Moves seeded deals between stages to generate `dealChange` events captured by this stream |
+| `deal_products` | Deal ↔ Product | `POST /v1/deals/{id}/products` | Attaches seeded products to deals |
+| `activity_types` | Activity Type | `POST /v1/activityTypes` | Creates custom activity types used by the seeded data |
+| `activities` | Activity | `POST /v1/activities` | Creates wave-based seeded activities linked to deals and persons |
+| `notes` | Note | `POST /v1/notes` | Creates wave-based seeded notes linked to deals, persons, and orgs |
+| `filters` | Filter | `POST /v1/filters` | Creates a seeded deal filter for QA verification |
+| `deal_fields` | Custom Deal Field | `POST /v1/dealFields` | Creates seeded custom fields (numeric + enum) |
+| `files` | File | `POST /v1/files` (multipart) | Uploads a small text attachment linked to a seeded deal |
 
 **Total: 14 of 16 streams seeded via script.**
 

--- a/spike/seed_pipedrive.py
+++ b/spike/seed_pipedrive.py
@@ -1,0 +1,693 @@
+"""
+Pipedrive Test Data Seeder
+==========================
+Seeds a Pipedrive account with enough data to exercise:
+
+  - PAGINATION   : >100 records in deals, persons, organizations, activities,
+                   notes so every page-based and cursor-based paginator fires.
+  - REPLICATION  : Two waves of records separated by a deliberate pause so
+                   a bookmark set after Wave 1 correctly picks up only Wave 2
+                   during an incremental sync.
+
+Usage:
+    # Full seed (Wave 1 + pause + Wave 2)
+    python spike/seed_pipedrive.py --config config.json
+
+    # Wave 1 only (then manually set bookmark, run tap, then run Wave 2)
+    python spike/seed_pipedrive.py --config config.json --wave 1
+
+    # Wave 2 only (after tap has consumed Wave 1 and saved a state)
+    python spike/seed_pipedrive.py --config config.json --wave 2
+
+Streams seeded:
+    pipelines, stages, organizations, persons, deals, deal_fields,
+    activity_types, activities, notes, products, deal_products,
+    filters, files, dealflow (stage-change events)
+
+Streams NOT seeded via script (see seed_pipedrive.md):
+    currencies, users
+"""
+
+import argparse
+import json
+import os
+import tempfile
+import time
+
+import requests
+
+BASE_V1 = "https://api.pipedrive.com/v1"
+BASE_V2 = "https://api.pipedrive.com/api/v2"
+
+# ---------------------------------------------------------------------------
+# Volume constants
+# ---------------------------------------------------------------------------
+# Pipedrive default page size is 100. We create slightly more than that so
+# every paginated stream must fetch at least 2 pages.
+PAGINATION_TARGET = 110   # records per paginated stream per wave
+DEALFLOW_MOVES    = 25    # stage-change events per wave
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _get(session, url, params=None):
+    resp = session.get(url, params=params or {})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _post(session, url, payload=None, files=None):
+    if files:
+        resp = session.post(url, data=payload, files=files)
+    else:
+        resp = session.post(url, json=payload)
+    if not resp.ok:
+        log(f"  ERROR {resp.status_code} → {resp.text[:300]}")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _put(session, url, payload):
+    resp = session.put(url, json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _existing_by_name(session, url, name_field="name"):
+    """Return id of the first item whose name matches, or None."""
+    page = _get(session, url, params={"limit": 500})
+    for item in (page.get("data") or []):
+        if item.get(name_field) == name_field:
+            return item["id"]
+    return None
+
+
+def find_by_name(items, name, field="name"):
+    for item in (items or []):
+        if item.get(field) == name:
+            return item
+    return None
+
+
+def log(msg):
+    print(f"[seed] {msg}", flush=True)
+
+
+def _throttle():
+    """Brief sleep to stay well within Pipedrive rate limits."""
+    time.sleep(0.12)
+
+
+def _get_all_pages(session, url, params=None):
+    """Fetch all records from a V1 paginated endpoint."""
+    params = dict(params or {})
+    params.setdefault("limit", 500)
+    params["start"] = 0
+    results = []
+    while True:
+        page = _get(session, url, params)
+        data = page.get("data") or []
+        results.extend(data)
+        pagination = (page.get("additional_data") or {}).get("pagination", {})
+        if not pagination.get("more_items_in_collection"):
+            break
+        params["start"] = pagination["next_start"]
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Pipelines  (stream: pipelines)
+# ---------------------------------------------------------------------------
+
+def seed_pipelines(session):
+    log("Seeding pipelines ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/pipelines")
+
+    result = []
+    for name in ["Stitch Pipeline Alpha", "Stitch Pipeline Beta"]:
+        p = find_by_name(existing, name)
+        if p:
+            log(f"  Pipeline '{name}' already exists (id={p['id']})")
+            result.append(p)
+        else:
+            resp = _post(session, f"{BASE_V1}/pipelines", {"name": name, "active": True})
+            p = resp["data"]
+            log(f"  Created pipeline '{name}' id={p['id']}")
+            result.append(p)
+            _throttle()
+    return result  # list of pipeline dicts
+
+
+# ---------------------------------------------------------------------------
+# Stages  (stream: stages)
+# 4 stages per pipeline → 8 total; tap must paginate if limit < 8.
+# ---------------------------------------------------------------------------
+
+STAGE_NAMES = ["Prospect", "Qualified", "Proposal", "Closed Won"]
+
+def seed_stages(session, pipelines):
+    log("Seeding stages ...")
+    all_stage_ids = []
+    for pipeline in pipelines:
+        pid = pipeline["id"]
+        existing = _get_all_pages(session, f"{BASE_V1}/stages", {"pipeline_id": pid})
+        for name in STAGE_NAMES:
+            s = find_by_name(existing, name)
+            if s:
+                log(f"  Stage '{name}' (pipeline {pid}) already exists (id={s['id']})")
+                all_stage_ids.append(s["id"])
+            else:
+                resp = _post(session, f"{BASE_V1}/stages", {"name": name, "pipeline_id": pid})
+                sid = resp["data"]["id"]
+                log(f"  Created stage '{name}' id={sid}")
+                all_stage_ids.append(sid)
+                _throttle()
+    return all_stage_ids
+
+
+# ---------------------------------------------------------------------------
+# Organizations  (stream: organizations)
+# Pagination target: PAGINATION_TARGET records per wave.
+# ---------------------------------------------------------------------------
+
+CITIES = ["San Francisco", "New York", "Chicago", "Austin", "Seattle",
+          "Boston", "Denver", "Atlanta", "Miami", "Portland"]
+
+def seed_organizations(session, wave, per_wave=None):
+    per_wave = per_wave or PAGINATION_TARGET
+    log(f"Seeding organizations (wave {wave}, {per_wave} records) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/organizations")
+    existing_names = {o["name"] for o in existing}
+
+    created = 0
+    for i in range(per_wave):
+        name = f"Stitch Org W{wave}-{i+1:04d}"
+        if name in existing_names:
+            continue
+        city = CITIES[i % len(CITIES)]
+        resp = _post(session, f"{BASE_V1}/organizations", {
+            "name": name,
+            "address": f"{i+1} Test Ave, {city}, CA 9{40000 + i}"
+        })
+        created += 1
+        if created % 20 == 0:
+            log(f"    ... {created}/{per_wave} organizations created")
+        _throttle()
+
+    log(f"  Created {created} organizations in wave {wave}")
+    return _get_all_pages(session, f"{BASE_V1}/organizations")
+
+
+# ---------------------------------------------------------------------------
+# Persons  (stream: persons)
+# Pagination target: PAGINATION_TARGET records per wave.
+# ---------------------------------------------------------------------------
+
+def seed_persons(session, org_list, wave, per_wave=None):
+    per_wave = per_wave or PAGINATION_TARGET
+    log(f"Seeding persons (wave {wave}, {per_wave} records) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/persons")
+    existing_names = {p["name"] for p in existing}
+
+    org_ids = [o["id"] for o in org_list]
+    created = 0
+    for i in range(per_wave):
+        name = f"Stitch Person W{wave}-{i+1:04d}"
+        if name in existing_names:
+            continue
+        resp = _post(session, f"{BASE_V1}/persons", {
+            "name": name,
+            "email": f"stitch.person.w{wave}.{i+1:04d}@stitchtest.invalid",
+            "phone": f"+1-800-{wave:01d}{i:06d}",
+            "org_id": org_ids[i % len(org_ids)]
+        })
+        created += 1
+        if created % 20 == 0:
+            log(f"    ... {created}/{per_wave} persons created")
+        _throttle()
+
+    log(f"  Created {created} persons in wave {wave}")
+    return _get_all_pages(session, f"{BASE_V1}/persons")
+
+
+# ---------------------------------------------------------------------------
+# Products  (stream: products)
+# ---------------------------------------------------------------------------
+
+def seed_products(session):
+    log("Seeding products ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/products")
+
+    products_data = [
+        {"name": "Stitch Data Connector",     "code": "SDC-001", "unit": "license",
+         "prices": [{"price": 299.00, "currency": "USD"}]},
+        {"name": "Stitch Professional Plan",  "code": "SPP-002", "unit": "month",
+         "prices": [{"price": 999.00, "currency": "USD"}]},
+        {"name": "Stitch Enterprise Edition", "code": "SEE-003", "unit": "year",
+         "prices": [{"price": 9999.00, "currency": "USD"}]},
+    ]
+
+    result = []
+    for p in products_data:
+        ex = find_by_name(existing, p["name"])
+        if ex:
+            log(f"  Product '{p['name']}' already exists (id={ex['id']})")
+            result.append(ex)
+        else:
+            resp = _post(session, f"{BASE_V1}/products", p)
+            prod = resp["data"]
+            log(f"  Created product '{p['name']}' id={prod['id']}")
+            result.append(prod)
+            _throttle()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Deals  (stream: deals)
+# Pagination target: PAGINATION_TARGET records per wave. Mix of statuses so
+# both open and won/lost deals appear in every replication key window.
+# ---------------------------------------------------------------------------
+
+DEAL_STATUSES_CYCLE = ["open", "open", "open", "won", "open", "open", "open", "lost"]
+
+def seed_deals(session, pipeline_ids, stage_ids, person_ids, org_ids, wave, per_wave=None):
+    per_wave = per_wave or PAGINATION_TARGET
+    log(f"Seeding deals (wave {wave}, {per_wave} records) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/deals",
+                              {"status": "all_not_deleted", "limit": 500})
+    existing_titles = {d["title"] for d in existing}
+
+    values = [1500, 3200, 7800, 14000, 28500, 52000, 99000, 150000, 4500, 8900]
+    created = 0
+
+    for i in range(per_wave):
+        title = f"Stitch Deal W{wave}-{i+1:04d}"
+        if title in existing_titles:
+            continue
+
+        status = DEAL_STATUSES_CYCLE[i % len(DEAL_STATUSES_CYCLE)]
+        stage_idx = i % len(stage_ids)
+        pipeline_idx = stage_idx // len(STAGE_NAMES)  # match stage to its pipeline
+
+        resp = _post(session, f"{BASE_V1}/deals", {
+            "title":       title,
+            "status":      status,
+            "value":       values[i % len(values)],
+            "currency":    "USD",
+            "pipeline_id": pipeline_ids[pipeline_idx % len(pipeline_ids)],
+            "stage_id":    stage_ids[stage_idx],
+            "person_id":   person_ids[i % len(person_ids)],
+            "org_id":      org_ids[i % len(org_ids)],
+        })
+        created += 1
+        if created % 20 == 0:
+            log(f"    ... {created}/{per_wave} deals created")
+        _throttle()
+
+    log(f"  Created {created} deals in wave {wave}")
+    return _get_all_pages(session, f"{BASE_V1}/deals",
+                          {"status": "all_not_deleted", "limit": 500})
+
+
+# ---------------------------------------------------------------------------
+# Dealflow  (stream: dealflow)
+# Move DEALFLOW_MOVES open deals to a different stage → creates dealChange
+# events with field_key='stage_id' captured by the dealflow stream.
+# ---------------------------------------------------------------------------
+
+def seed_dealflow(session, deals, stage_ids, wave):
+    log(f"Seeding dealflow stage-change events (wave {wave}) ...")
+    open_deals = [d for d in deals if d.get("status") == "open"]
+    moved = 0
+    for i, deal in enumerate(open_deals[:DEALFLOW_MOVES]):
+        current_stage = deal.get("stage_id")
+        if current_stage in stage_ids:
+            next_stage = stage_ids[(stage_ids.index(current_stage) + 1) % len(stage_ids)]
+        else:
+            next_stage = stage_ids[0]
+        _put(session, f"{BASE_V1}/deals/{deal['id']}", {"stage_id": next_stage})
+        moved += 1
+        if moved % 10 == 0:
+            log(f"    ... {moved}/{DEALFLOW_MOVES} deals moved")
+        _throttle()
+    log(f"  Created {moved} dealflow events in wave {wave}")
+
+
+# ---------------------------------------------------------------------------
+# Deal Products  (stream: deal_products)
+# Pagination target: PAGINATION_TARGET attachments per wave.
+# ---------------------------------------------------------------------------
+
+def seed_deal_products(session, deals, products, wave):
+    log(f"Seeding deal_products (wave {wave}) ...")
+    attached = 0
+    for i in range(PAGINATION_TARGET):
+        deal    = deals[i % len(deals)]
+        product = products[i % len(products)]
+        existing = (_get(session, f"{BASE_V1}/deals/{deal['id']}/products").get("data") or [])
+        if any(p.get("product_id") == product["id"] for p in existing):
+            continue
+        _post(session, f"{BASE_V1}/deals/{deal['id']}/products", {
+            "product_id": product["id"],
+            "item_price":  product.get("prices", [{}])[0].get("price", 100),
+            "quantity":    (i % 5) + 1,
+            "currency":    "USD"
+        })
+        attached += 1
+        if attached % 20 == 0:
+            log(f"    ... {attached} deal_products attached")
+        _throttle()
+    log(f"  Attached {attached} deal_products in wave {wave}")
+
+
+# ---------------------------------------------------------------------------
+# Activity Types  (stream: activity_types)
+# ---------------------------------------------------------------------------
+
+def seed_activity_types(session):
+    log("Seeding activity_types ...")
+    existing = (_get(session, f"{BASE_V1}/activityTypes").get("data") or [])
+
+    types = [
+        ("Stitch Demo Call",       "call"),
+        ("Stitch Follow-up Email", "email"),
+        ("Stitch On-site Visit",   "meeting"),
+        ("Stitch Webinar",         "lunch"),
+    ]
+    for name, icon_key in types:
+        ex = find_by_name(existing, name)
+        if ex:
+            log(f"  Activity type '{name}' already exists (id={ex['id']})")
+        else:
+            resp = _post(session, f"{BASE_V1}/activityTypes", {"name": name, "icon_key": icon_key})
+            log(f"  Created activity type '{name}' id={resp['data']['id']}")
+            _throttle()
+
+
+# ---------------------------------------------------------------------------
+# Activities  (stream: activities)
+# Pagination target: PAGINATION_TARGET records per wave.
+# ---------------------------------------------------------------------------
+
+ACTIVITY_TYPES_ROTATE = ["call", "email", "meeting", "lunch", "task"]
+DUE_DATES = ["2026-06-01", "2026-06-15", "2026-07-01", "2026-07-15", "2026-08-01"]
+
+def seed_activities(session, deal_ids, person_ids, wave, per_wave=None):
+    per_wave = per_wave or PAGINATION_TARGET
+    log(f"Seeding activities (wave {wave}, {per_wave} records) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/activities")
+    existing_subjects = {a.get("subject", "") for a in existing}
+
+    created = 0
+    for i in range(per_wave):
+        subject = f"Stitch Activity W{wave}-{i+1:04d}"
+        if subject in existing_subjects:
+            continue
+        _post(session, f"{BASE_V1}/activities", {
+            "subject":   subject,
+            "type":      ACTIVITY_TYPES_ROTATE[i % len(ACTIVITY_TYPES_ROTATE)],
+            "deal_id":   deal_ids[i % len(deal_ids)],
+            "person_id": person_ids[i % len(person_ids)],
+            "due_date":  DUE_DATES[i % len(DUE_DATES)],
+            "due_time":  f"{8 + (i % 10):02d}:00",
+            "duration":  "00:30",
+            "done":      1 if i % 5 == 0 else 0,
+            "note":      f"Stitch auto-seeded activity wave={wave} seq={i+1}"
+        })
+        created += 1
+        if created % 20 == 0:
+            log(f"    ... {created}/{per_wave} activities created")
+        _throttle()
+    log(f"  Created {created} activities in wave {wave}")
+
+
+# ---------------------------------------------------------------------------
+# Notes  (stream: notes)
+# Pagination target: PAGINATION_TARGET records per wave.
+# ---------------------------------------------------------------------------
+
+def seed_notes(session, deal_ids, person_ids, org_ids, wave, per_wave=None):
+    per_wave = per_wave or PAGINATION_TARGET
+    log(f"Seeding notes (wave {wave}, {per_wave} records) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/notes")
+    existing_contents = {n.get("content", "") for n in existing}
+
+    created = 0
+    for i in range(per_wave):
+        content = f"Stitch seed note wave={wave} seq={i+1:04d}: auto-generated for integration testing."
+        if content in existing_contents:
+            continue
+        payload = {"content": content}
+        r = i % 3
+        if r == 0:
+            payload["deal_id"]   = deal_ids[i % len(deal_ids)]
+        elif r == 1:
+            payload["person_id"] = person_ids[i % len(person_ids)]
+        else:
+            payload["org_id"]    = org_ids[i % len(org_ids)]
+        _post(session, f"{BASE_V1}/notes", payload)
+        created += 1
+        if created % 20 == 0:
+            log(f"    ... {created}/{per_wave} notes created")
+        _throttle()
+    log(f"  Created {created} notes in wave {wave}")
+
+
+# ---------------------------------------------------------------------------
+# Filters  (stream: filters)
+# ---------------------------------------------------------------------------
+
+def seed_filters(session):
+    log("Seeding filters ...")
+    existing = (_get(session, f"{BASE_V1}/filters", params={"type": "deals"}).get("data") or [])
+
+    filter_name = "Stitch — Open Deals Filter"
+    ex = find_by_name(existing, filter_name)
+    if ex:
+        log(f"  Filter '{filter_name}' already exists (id={ex['id']})")
+        return
+
+    # Fetch the numeric ID for the 'status' deal field
+    deal_fields = (_get(session, f"{BASE_V1}/dealFields", params={"limit": 200}).get("data") or [])
+    status_field = next((f for f in deal_fields if f.get("key") == "status"), None)
+    if not status_field:
+        log("  Could not find 'status' deal field — skipping filter creation.")
+        return
+
+    resp = _post(session, f"{BASE_V1}/filters", {
+        "name": filter_name,
+        "type": "deals",
+        "conditions": {
+            "glue": "and",
+            "conditions": [
+                {
+                    "glue": "and",
+                    "conditions": [
+                        {
+                            "object": "deal",
+                            "field_id": status_field["id"],
+                            "operator": "=",
+                            "value": "open",
+                            "extra_value": None
+                        }
+                    ]
+                }
+            ]
+        }
+    })
+    log(f"  Created filter id={resp['data']['id']}")
+
+
+# ---------------------------------------------------------------------------
+# Deal Fields  (stream: deal_fields)
+# ---------------------------------------------------------------------------
+
+def seed_deal_fields(session):
+    log("Seeding deal_fields (custom) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/dealFields")
+
+    fields = [
+        {"name": "Stitch Contract Value",   "field_type": "double"},
+        {"name": "Stitch Integration Type", "field_type": "enum",
+         "options": [{"label": "API"}, {"label": "File"}, {"label": "Database"}]},
+        {"name": "Stitch Go-Live Date",     "field_type": "date"},
+        {"name": "Stitch Internal Notes",   "field_type": "text"},
+    ]
+
+    for f in fields:
+        ex = find_by_name(existing, f["name"])
+        if ex:
+            log(f"  Deal field '{f['name']}' already exists (id={ex['id']})")
+        else:
+            resp = _post(session, f"{BASE_V1}/dealFields", f)
+            log(f"  Created deal field '{f['name']}' id={resp['data']['id']}")
+            _throttle()
+
+
+# ---------------------------------------------------------------------------
+# Files  (stream: files)
+# Upload per_wave small attachments spread across deals.
+# ---------------------------------------------------------------------------
+
+def seed_files(session, deal_ids, wave, per_wave=10):
+    log(f"Seeding files (wave {wave}, {per_wave} files) ...")
+    existing = _get_all_pages(session, f"{BASE_V1}/files")
+    existing_names = {f.get("name", "") for f in existing}
+    content = b"Stitch integration test attachment - safe to delete.\n"
+    created = 0
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i in range(per_wave):
+            filename = f"stitch_seed_w{wave}_{i+1:04d}.txt"
+            if filename in existing_names:
+                log(f"  File '{filename}' already exists")
+                continue
+            fpath = os.path.join(tmpdir, filename)
+            with open(fpath, "wb") as fh:
+                fh.write(content + f"file={i+1} wave={wave}\n".encode())
+            with open(fpath, "rb") as fh:
+                _post(
+                    session,
+                    f"{BASE_V1}/files",
+                    payload={"deal_id": deal_ids[i % len(deal_ids)]},
+                    files={"file": (filename, fh, "text/plain")},
+                )
+            created += 1
+            _throttle()
+    log(f"  Uploaded {created} files in wave {wave}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def build_session(api_token):
+    session = requests.Session()
+    session.params = {"api_token": api_token}
+    session.headers.update({"Accept": "application/json"})
+    return session
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Seed Pipedrive test account with enough data for pagination and replication tests."
+    )
+    parser.add_argument("--api-token", default="", help="Pipedrive API token")
+    parser.add_argument("--config", help="Path to tap config.json (reads api_token from it)")
+    parser.add_argument(
+        "--wave",
+        type=int,
+        choices=[0, 1, 2],
+        default=0,
+        help="0=both waves with pause (default), 1=wave 1 only, 2=wave 2 only",
+    )
+    args = parser.parse_args()
+
+    api_token = args.api_token
+    if args.config:
+        with open(args.config) as f:
+            api_token = json.load(f).get("api_token", api_token)
+
+    if not api_token:
+        parser.error("Provide --api-token or --config with an api_token field.")
+
+    session = build_session(api_token)
+
+    log("=" * 60)
+    log("Pipedrive Test Data Seeder")
+    log(f"Pagination target : {PAGINATION_TARGET} records per stream per wave")
+    log(f"Dealflow events   : {DEALFLOW_MOVES} per wave")
+    log(f"Wave mode         : {args.wave}  (0=both, 1=wave1 only, 2=wave2 only)")
+    log("=" * 60)
+
+    # ── Shared infrastructure (idempotent regardless of wave) ─────────────────
+    pipelines  = seed_pipelines(session)          # returns list of pipeline dicts
+    pipeline_ids = [p["id"] for p in pipelines]
+    stage_ids  = seed_stages(session, pipelines)  # all stage ids across pipelines
+    products   = seed_products(session)
+    seed_activity_types(session)
+    seed_deal_fields(session)
+
+    # ── Wave 1 ────────────────────────────────────────────────────────────────
+    if args.wave in (0, 1):
+        log("\n── WAVE 1 ──────────────────────────────────────────────────")
+
+        orgs_w1    = seed_organizations(session, wave=1, per_wave=PAGINATION_TARGET)
+        persons_w1 = seed_persons(session, orgs_w1, wave=1, per_wave=PAGINATION_TARGET)
+        org_ids_w1    = [o["id"] for o in orgs_w1]
+        person_ids_w1 = [p["id"] for p in persons_w1]
+
+        deals_w1  = seed_deals(
+            session, pipeline_ids, stage_ids,
+            person_ids_w1, org_ids_w1,
+            wave=1, per_wave=PAGINATION_TARGET
+        )
+        deal_ids_w1 = [d["id"] for d in deals_w1]
+
+        seed_dealflow(session, deals_w1, stage_ids, wave=1)
+        seed_deal_products(session, deals_w1, products, wave=1)
+        seed_activities(session, deal_ids_w1, person_ids_w1, wave=1, per_wave=PAGINATION_TARGET)
+        seed_notes(session, deal_ids_w1, person_ids_w1, org_ids_w1, wave=1, per_wave=PAGINATION_TARGET)
+        seed_filters(session)
+        seed_files(session, deal_ids_w1, wave=1, per_wave=10)
+
+    # ── Replication pause ─────────────────────────────────────────────────────
+    # After Wave 1, run the tap to get a full sync and save state.
+    # The bookmark will be set to "now". Wave 2 records arrive after this pause
+    # and should be the ONLY records emitted during the next incremental sync.
+    if args.wave == 0:
+        PAUSE = 15
+        log(f"\n── REPLICATION PAUSE ({PAUSE}s) ─────────────────────────────────")
+        log("   NOW is a good time to:")
+        log("     1. Run the tap to perform a full sync (saves state bookmark)")
+        log("     2. Note the bookmark timestamp printed in the state output")
+        log("   Wave 2 records will be created after this pause. An incremental")
+        log("   sync from the saved bookmark should return only Wave 2 records.")
+        for remaining in range(PAUSE, 0, -1):
+            print(f"\r   Waiting {remaining:2d}s ...", end="", flush=True)
+            time.sleep(1)
+        print()
+
+    # ── Wave 2 ────────────────────────────────────────────────────────────────
+    if args.wave in (0, 2):
+        W2 = PAGINATION_TARGET // 2  # half volume — enough to verify incremental pickup
+        log(f"\n── WAVE 2 (volume={W2} per stream) ────────────────────────────")
+
+        orgs_all    = seed_organizations(session, wave=2, per_wave=W2)
+        persons_all = seed_persons(session, orgs_all, wave=2, per_wave=W2)
+        org_ids_all    = [o["id"] for o in orgs_all]
+        person_ids_all = [p["id"] for p in persons_all]
+
+        deals_all = seed_deals(
+            session, pipeline_ids, stage_ids,
+            person_ids_all, org_ids_all,
+            wave=2, per_wave=W2
+        )
+        deal_ids_all = [d["id"] for d in deals_all]
+
+        seed_dealflow(session, deals_all, stage_ids, wave=2)
+        seed_deal_products(session, deals_all, products, wave=2)
+        seed_activities(session, deal_ids_all, person_ids_all, wave=2, per_wave=W2)
+        seed_notes(session, deal_ids_all, person_ids_all, org_ids_all, wave=2, per_wave=W2)
+        seed_files(session, deal_ids_all, wave=2, per_wave=5)
+
+    log("\n" + "=" * 60)
+    log("Seeding complete.")
+    log("")
+    log("Approximate record counts (wave1 / wave2):")
+    log(f"  deals, organizations, persons  : {PAGINATION_TARGET} / {PAGINATION_TARGET // 2}  (pagination fires at >100)")
+    log(f"  activities, notes              : {PAGINATION_TARGET} / {PAGINATION_TARGET // 2}")
+    log(f"  deal_products                  : {PAGINATION_TARGET} / {PAGINATION_TARGET // 2}")
+    log(f"  dealflow events                : {DEALFLOW_MOVES} / {DEALFLOW_MOVES}")
+    log("")
+    log("Next steps:")
+    log("  1. Full sync:      tap-pipedrive --config config.json --catalog catalog.json")
+    log("  2. Save state, then run --wave 2 to populate incremental-only records")
+    log("  3. Incremental:    tap-pipedrive --config config.json --catalog catalog.json --state state.json")
+    log("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -271,8 +271,13 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         if not current_bookmark or current_bookmark >= self.initial_state:
             return True
 
-        # Stop fetching if the current replication value is less than the earliest state(bookmark)
+        # Stop fetching because this record is older than the bookmark.
+        # Commit the tracked max now — update_state won't be called for this row
+        # since write_record returns False.
         self.more_items_in_collection = False
+        max_seen = getattr(self, '_max_seen_bookmark', None)
+        if max_seen and max_seen >= self.earliest_state:
+            self.earliest_state = max_seen
         return False
 
     def set_initial_state(self, state, start_date):

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -45,12 +45,28 @@ class PipedriveStream(object):
     def get_name(self):
         return self.endpoint
 
+    @staticmethod
+    def _normalize_bookmark(value):
+        """Normalize a Pipedrive timestamp to '%Y-%m-%dT%H:%M:%SZ' (no microseconds).
+
+        Pipedrive API rows often carry microseconds (e.g. '...27.000000Z') while
+        stored bookmarks are already stripped to second precision.  Comparing the
+        raw string lexicographically can give wrong results because '.0' < 'Z' in
+        ASCII, making a record at the *same* second appear older than the bookmark.
+        Normalizing before any comparison avoids this class of off-by-one bugs.
+        """
+        if not value:
+            return None
+        try:
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y-%m-%dT%H:%M:%SZ")
+        except (ValueError, TypeError):
+            return value
+
     def update_state(self, row):
         """
         Update the state of the stream
         """
-        current_bookmark = row.get(self.state_field)
-        current_bookmark = datetime.strptime(current_bookmark, "%Y-%m-%dT%H:%M:%S.000000Z").strftime("%Y-%m-%dT%H:%M:%SZ") if current_bookmark else None
+        current_bookmark = self._normalize_bookmark(row.get(self.state_field))
         if current_bookmark and current_bookmark >= self.earliest_state:
             self.earliest_state = current_bookmark
 
@@ -60,11 +76,7 @@ class PipedriveStream(object):
         """
         bookmark = state.get("bookmarks", {}).get(self.schema, {}).get(self.state_field) or start_date
         # Normalize to the format Pipedrive accepts (no microseconds)
-        try:
-            bookmark = datetime.strptime(bookmark, "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y-%m-%dT%H:%M:%SZ")
-        except (ValueError, TypeError):
-            pass
-        self.initial_state = bookmark
+        self.initial_state = self._normalize_bookmark(bookmark) or bookmark
         self.earliest_state = self.initial_state
 
     def has_data(self):
@@ -102,7 +114,7 @@ class PipedriveStream(object):
         """
         Write the record to the stream
         """
-        current_bookmark = row.get(self.state_field)
+        current_bookmark = self._normalize_bookmark(row.get(self.state_field))
         if not current_bookmark or current_bookmark >= self.initial_state:
             return True
 
@@ -267,7 +279,7 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         """
         Write the record to the stream
         """
-        current_bookmark = row.get(self.state_field)
+        current_bookmark = self._normalize_bookmark(row.get(self.state_field))
         if not current_bookmark or current_bookmark >= self.initial_state:
             return True
 
@@ -291,8 +303,7 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         So if some interruption happens, it would miss some records.
         Track the maximum bookmark seen across all pages and commit it only when pagination is complete.
         """
-        current_bookmark = row.get(self.state_field)
-        current_bookmark = datetime.strptime(current_bookmark, "%Y-%m-%dT%H:%M:%S.000000Z").strftime("%Y-%m-%dT%H:%M:%SZ") if current_bookmark else None
+        current_bookmark = self._normalize_bookmark(row.get(self.state_field))
 
         # Always track the running maximum across all processed rows
         if current_bookmark:
@@ -318,7 +329,7 @@ class DynamicSchemaStream(PipedriveStream):
                 fields_params = {
                     "limit" : self.limit,
                     "start" : self.start
-                } 
+                }
 
                 with singer.metrics.http_request_timer(self.schema) as timer:
                     try:
@@ -328,12 +339,12 @@ class DynamicSchemaStream(PipedriveStream):
 
                     timer.tags[singer.metrics.Tag.http_status_code] = fields_response.status_code
 
-                    try: 
+                    try:
                         properties = fields_response.json()
                         for prop in properties['data']:
                             if prop['key'] not in schema['properties']:
                                 schema['properties'][prop['key']] = prop
-                        
+
                                 property_content = {
                                     'type': ['null']
                                 }

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -260,7 +260,10 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
 
     sort_by = 'update_time'
     sort_direction = 'desc'
-    _max_seen_bookmark = None
+
+    def __init__(self):
+        super().__init__()
+        self._max_seen_bookmark = None 
 
     def update_request_params(self, params):
         """

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -269,19 +269,31 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         self.more_items_in_collection = False
         return False
 
+    def set_initial_state(self, state, start_date):
+        super().set_initial_state(state, start_date)
+        self._max_seen_bookmark = None
+
     def update_state(self, row):
         """
         Update the state only after the stream has been fully processed.
         Because it fetched all records in descending order, the first records will have latest replication value.
         So if some interruption happens, it would miss some records.
+        Track the maximum bookmark seen across all pages and commit it only when pagination is complete.
         """
-        if self.more_items_in_collection:
-            return
-
         current_bookmark = row.get(self.state_field)
         current_bookmark = datetime.strptime(current_bookmark, "%Y-%m-%dT%H:%M:%S.000000Z").strftime("%Y-%m-%dT%H:%M:%SZ") if current_bookmark else None
-        if current_bookmark and current_bookmark >= self.earliest_state:
-            self.earliest_state = current_bookmark
+
+        # Always track the running maximum across all processed rows
+        if current_bookmark:
+            max_seen = getattr(self, '_max_seen_bookmark', None)
+            if max_seen is None or current_bookmark > max_seen:
+                self._max_seen_bookmark = current_bookmark
+
+        # Only commit the maximum to state when all pages have been fetched
+        if not self.more_items_in_collection:
+            max_seen = getattr(self, '_max_seen_bookmark', None)
+            if max_seen and max_seen >= self.earliest_state:
+                self.earliest_state = max_seen
 
 class DynamicSchemaStream(PipedriveStream):
     static_fields = []

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -58,7 +58,13 @@ class PipedriveStream(object):
         """
         Set the initial state of the stream
         """
-        self.initial_state = state.get("bookmarks", {}).get(self.schema, {}).get(self.state_field) or start_date
+        bookmark = state.get("bookmarks", {}).get(self.schema, {}).get(self.state_field) or start_date
+        # Normalize to the format Pipedrive accepts (no microseconds)
+        try:
+            bookmark = datetime.strptime(bookmark, "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y-%m-%dT%H:%M:%SZ")
+        except (ValueError, TypeError):
+            pass
+        self.initial_state = bookmark
         self.earliest_state = self.initial_state
 
     def has_data(self):

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -260,6 +260,7 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
 
     sort_by = 'update_time'
     sort_direction = 'desc'
+    _max_seen_bookmark = None
 
     def update_request_params(self, params):
         """
@@ -287,9 +288,8 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         # Commit the tracked max now — update_state won't be called for this row
         # since write_record returns False.
         self.more_items_in_collection = False
-        max_seen = getattr(self, '_max_seen_bookmark', None)
-        if max_seen and max_seen >= self.earliest_state:
-            self.earliest_state = max_seen
+        if self._max_seen_bookmark and self._max_seen_bookmark >= self.earliest_state:
+            self.earliest_state = self._max_seen_bookmark
         return False
 
     def set_initial_state(self, state, start_date):
@@ -305,17 +305,15 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         """
         current_bookmark = self._normalize_bookmark(row.get(self.state_field))
 
-        # Always track the running maximum across all processed rows
+        # Track the highest bookmark seen across all pages (records arrive newest-first)
         if current_bookmark:
-            max_seen = getattr(self, '_max_seen_bookmark', None)
-            if max_seen is None or current_bookmark > max_seen:
+            if self._max_seen_bookmark is None or current_bookmark > self._max_seen_bookmark:
                 self._max_seen_bookmark = current_bookmark
 
-        # Only commit the maximum to state when all pages have been fetched
+        # Commit the running maximum to state once all pages are exhausted
         if not self.more_items_in_collection:
-            max_seen = getattr(self, '_max_seen_bookmark', None)
-            if max_seen and max_seen >= self.earliest_state:
-                self.earliest_state = max_seen
+            if self._max_seen_bookmark and self._max_seen_bookmark >= self.earliest_state:
+                self.earliest_state = self._max_seen_bookmark
 
 class DynamicSchemaStream(PipedriveStream):
     static_fields = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -257,7 +257,7 @@ class PipedriveBaseTest(unittest.TestCase):
         found_catalog_names = set(map(lambda c: c['stream_name'] , found_catalogs))
 
         self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
-        print("discovered schemas are OK")
+        self.LOGGER.info("discovered schemas are OK")
 
         return found_catalogs
 
@@ -279,9 +279,13 @@ class PipedriveBaseTest(unittest.TestCase):
             self, conn_id, self.expected_streams(), self.expected_primary_keys())
         self.assertGreater(
             sum(sync_record_count.values()), 0,
-            msg="failed to replicate any data: {}".format(sync_record_count)
+            msg=(
+                "No records were replicated for any stream: {}.\n"
+                "Ensure the Pipedrive test account has been seeded with data. "
+                "See spike/seed_pipedrive.md for instructions."
+            ).format(sync_record_count)
         )
-        print("total replicated row count: {}".format(sum(sync_record_count.values())))
+        self.LOGGER.info("total replicated row count: %d", sum(sync_record_count.values()))
 
         return sync_record_count
 
@@ -310,7 +314,7 @@ class PipedriveBaseTest(unittest.TestCase):
 
             # Verify all testable streams are selected
             selected = catalog_entry.get('annotated-schema').get('selected')
-            print("Validating selection on {}: {}".format(cat['stream_name'], selected))
+            self.LOGGER.info("Validating selection on %s: %s", cat['stream_name'], selected)
             if cat['stream_name'] not in expected_selected:
                 self.assertFalse(selected, msg="Stream selected, but not testable.")
                 continue # Skip remaining assertions if we aren't selecting this stream
@@ -320,8 +324,8 @@ class PipedriveBaseTest(unittest.TestCase):
                 # Verify all fields within each selected stream are selected
                 for field, field_props in catalog_entry.get('annotated-schema').get('properties').items():
                     field_selected = field_props.get('selected')
-                    print("\tValidating selection on {}.{}: {}".format(
-                        cat['stream_name'], field, field_selected))
+                    self.LOGGER.info("\tValidating selection on %s.%s: %s",
+                                     cat['stream_name'], field, field_selected)
                     self.assertTrue(field_selected, msg="Field not selected.")
             else:
                 # Verify only automatic fields are selected
@@ -406,7 +410,7 @@ class PipedriveBaseTest(unittest.TestCase):
 
     def is_start_date_appling(self, stream):
         if self.expected_metadata().get(stream).get(self.STARTDATE_KEYS,None) is None:
-            return False 
+            return False
         return True
 
     def dt_to_ts(self, dtime, format):

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -66,7 +66,14 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
             if values:
                 # Pick a value at the 50% mark so the second sync returns roughly half the records
                 mid_idx = len(values) // 2
-                simulated_states[stream] = {replication_key: values[mid_idx]}
+                mid_value = values[mid_idx]
+                # Normalize to bookmark format (strip microseconds) so dt_to_ts can parse it
+                from datetime import datetime as _dt
+                try:
+                    mid_value = _dt.strptime(mid_value, "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y-%m-%dT%H:%M:%SZ")
+                except (ValueError, TypeError):
+                    pass
+                simulated_states[stream] = {replication_key: mid_value}
 
         # setting simulated bookmark as starting point for 2nd sync
         for stream, updated_state in simulated_states.items():

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -48,21 +48,27 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
         ### Update State
         ##########################################################################
         new_state = {'bookmarks': dict()}
-        simulated_states = {
-            "notes": {"update_time": "2026-03-04T08:45:00Z"},
-            "activities": {"update_time": "2026-03-04T08:45:00Z"},
-            "deals": {"update_time": "2026-03-04T08:45:00Z"},
-            "files": {"update_time": "2026-03-04T08:45:00Z"},
-            "organizations": {"update_time": "2026-03-04T08:45:00Z"},
-            "persons": {"update_time": "2026-03-04T08:45:00Z"},
-            "products": {"update_time": "2026-03-04T08:45:00Z"},
-            # "dealflow": {"log_time": "2026-02-17T05:40:00Z"},
-            # Skipping users - only 1 user, assertLess(1,1) can never pass
-            # "users": {"modified": "2026-02-17T05:40:00Z"},
-            # BUG TDL-25987: We observed few records with null replication key values for deal_fields stream
-            # "deal_fields": {"update_time": "2023-04-15T17:25:16Z"}
-        }
-        # setting 'second_start_date' as bookmark for running 2nd sync
+
+        # Dynamically compute simulated states using the median replication-key value from the
+        # first sync. This ensures the second sync retrieves a strict subset of first sync records
+        # regardless of when the test data was created, avoiding failures caused by hardcoded dates
+        # that pre-date all seeded records.
+        simulated_states = {}
+        for stream in expected_streams:
+            if expected_replication_methods.get(stream) != self.INCREMENTAL:
+                continue
+            replication_key = list(expected_replication_keys[stream])[0]
+            messages = [r.get('data') for r in
+                        first_sync_records.get(stream, {}).get('messages', [])
+                        if r.get('action') == 'upsert']
+            values = sorted([m.get(replication_key) for m in messages
+                             if m and m.get(replication_key)])
+            if values:
+                # Pick a value at the 50% mark so the second sync returns roughly half the records
+                mid_idx = len(values) // 2
+                simulated_states[stream] = {replication_key: values[mid_idx]}
+
+        # setting simulated bookmark as starting point for 2nd sync
         for stream, updated_state in simulated_states.items():
             new_state['bookmarks'][stream] = updated_state
 

--- a/tests/test_pipedrive_start_date.py
+++ b/tests/test_pipedrive_start_date.py
@@ -4,7 +4,7 @@ from base import PipedriveBaseTest
 class PipedriveStartDateTest(PipedriveBaseTest):
 
     start_date_1 = ""
-    start_date_2 = "2026-03-05T00:00:00Z"
+    start_date_2 = "2026-04-25T00:00:00Z"
 
     @staticmethod
     def name():

--- a/tests/test_pipedrive_start_date.py
+++ b/tests/test_pipedrive_start_date.py
@@ -24,7 +24,7 @@ class PipedriveStartDateTest(PipedriveBaseTest):
         # and start_date_2_epoch. So the assertion of assertGreater b/t sync_1 and sync_2 records
         # is failing
         expected_streams = self.expected_streams() - {"deal_fields", "stages", "pipelines", "filters", "activity_types"}
-        
+
         # Skipping below streams it make lot of API calls and we have daily quota limit for trail account
         expected_streams = expected_streams - {"dealflow", "deal_products"}
         ##########################################################################
@@ -50,7 +50,7 @@ class PipedriveStartDateTest(PipedriveBaseTest):
         ### Update START DATE Between Syncs
         ##########################################################################
 
-        print("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(self.start_date, self.start_date_2))
+        self.LOGGER.info("REPLICATION START DATE CHANGE: %s ===>>> %s", self.start_date, self.start_date_2)
         self.start_date = self.start_date_2
 
         ##########################################################################

--- a/tests/unittests/test_dealflow_bookmark.py
+++ b/tests/unittests/test_dealflow_bookmark.py
@@ -2,8 +2,6 @@ from unittest import mock
 from tap_pipedrive.tap import PipedriveTap
 from tap_pipedrive.streams.dealflow import DealStageChangeStream
 import unittest
-import pendulum
-from pendulum.tz.timezone import Timezone
 
 class Mockresponse:
     def __init__(self, status_code, json, headers=None):

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -50,7 +50,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         self.assertEqual(mocked_jsondecode_successful_request.call_count, 1)
 
     def test_json_decode_exception(self, mocked_jsondecode_failing_request, mocked_sleep):
-        json_decode_error_str = '{\Currency\': \'value\'}'
+        json_decode_error_str = "{'Currency': 'value'}"
         mocked_jsondecode_failing_request.return_value = get_mock_http_response(200, json_decode_error_str)
 
         with self.assertRaises(simplejson.scanner.JSONDecodeError) as e:
@@ -66,7 +66,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
 
         expected_error_message = "HTTP-error-code: 400, Error: Request is missing or has a bad parameter."
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -79,7 +79,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -92,7 +92,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 402, Error: Company account is not open (possible reason: trial expired, payment details not entered)."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -105,7 +105,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 403, Error: Invalid authorization credentials or permissions."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -118,7 +118,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 404, Error: The requested resource does not exist."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -131,7 +131,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 410, Error: The old resource is permanently unavailable."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -144,7 +144,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 415, Error: The feature is not enabled."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -157,7 +157,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 422, Error: Webhook limit reached."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -171,7 +171,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 429, Error: Rate limit has been exceeded. Please retry after 2 seconds."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 3)
 
@@ -185,7 +185,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 429, Error: Daily Rate limit has been exceeded. Please retry after 200 seconds."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 1)
 
@@ -198,7 +198,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 500, Error: Internal Service Error from PipeDrive."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 5)
 
@@ -211,7 +211,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 501, Error: Functionality does not exist."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 5)
 
@@ -224,7 +224,7 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 503, Error: Schedule maintenance on Pipedrive's end."
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 5)
 
@@ -237,6 +237,6 @@ class TestExecuteRequestExceptionHandling(unittest.TestCase):
         expected_error_message = "HTTP-error-code: 524, Error: Unknown Error"
 
         # Verifying the message formed for the custom exception
-        self.assertEquals(str(e.exception), expected_error_message)
+        self.assertEqual(str(e.exception), expected_error_message)
 
         self.assertEqual(mocked_request.call_count, 5)

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -83,6 +83,37 @@ class TestPipedriveStreamHasData(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# TestNormalizeBookmark
+# ---------------------------------------------------------------------------
+
+class TestNormalizeBookmark(unittest.TestCase):
+    """Verify _normalize_bookmark strips microseconds to second precision."""
+
+    def test_strips_microseconds(self):
+        """000000Z suffix is stripped to plain Z format."""
+        result = PipedriveStream._normalize_bookmark("2024-06-01T10:20:30.000000Z")
+        self.assertEqual(result, "2024-06-01T10:20:30Z")
+
+    def test_strips_non_zero_microseconds(self):
+        """Non-zero microseconds are also stripped (fractional seconds are not kept)."""
+        result = PipedriveStream._normalize_bookmark("2024-06-01T10:20:30.123456Z")
+        self.assertEqual(result, "2024-06-01T10:20:30Z")
+
+    def test_already_normalized_value_is_returned_unchanged(self):
+        """A value already in the normalized format passes through unchanged."""
+        result = PipedriveStream._normalize_bookmark("2024-06-01T10:20:30Z")
+        self.assertEqual(result, "2024-06-01T10:20:30Z")
+
+    def test_returns_none_for_none_input(self):
+        """None input returns None."""
+        self.assertIsNone(PipedriveStream._normalize_bookmark(None))
+
+    def test_returns_none_for_empty_string(self):
+        """Empty string returns None."""
+        self.assertIsNone(PipedriveStream._normalize_bookmark(""))
+
+
+# ---------------------------------------------------------------------------
 # TestPipedriveStreamSetInitialState
 # ---------------------------------------------------------------------------
 
@@ -169,6 +200,25 @@ class TestPipedriveStreamWriteRecord(unittest.TestCase):
         stream.initial_state = "2024-06-01T00:00:00Z"
         row = {"update_time": "2024-01-01T00:00:00Z"}
         self.assertFalse(stream.write_record(row))
+
+    def test_returns_true_when_record_has_microseconds_equal_to_initial_state(self):
+        """write_record returns True when a microsecond-format row equals the bookmark.
+
+        '2024-06-01T00:00:00.000000Z' must compare equal to '2024-06-01T00:00:00Z'
+        after normalization; without normalization the lexicographic comparison
+        '...00.000000Z' < '...00Z' would incorrectly return False.
+        """
+        stream = _SimpleStream()
+        stream.initial_state = "2024-06-01T00:00:00Z"
+        row = {"update_time": "2024-06-01T00:00:00.000000Z"}
+        self.assertTrue(stream.write_record(row))
+
+    def test_returns_true_when_record_has_microseconds_after_initial_state(self):
+        """write_record returns True when microsecond row is newer than bookmark."""
+        stream = _SimpleStream()
+        stream.initial_state = "2024-06-01T00:00:00Z"
+        row = {"update_time": "2024-06-01T00:00:01.000000Z"}
+        self.assertTrue(stream.write_record(row))
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +397,21 @@ class TestPipedriveIncrementalStreamUsingSortWriteRecord(unittest.TestCase):
         result = stream.write_record(row)
         self.assertFalse(result)
         self.assertEqual(stream.earliest_state, "2024-06-01T00:00:00Z")
+
+    def test_returns_true_when_row_microseconds_equal_initial_state(self):
+        """write_record returns True when microsecond-format row equals the bookmark.
+
+        '2024-06-01T00:00:00.000000Z' must compare equal to '2024-06-01T00:00:00Z'
+        after normalization; raw string comparison would incorrectly stop pagination.
+        """
+        stream = _SimpleIncrementalSortStream()
+        stream.initial_state = "2024-06-01T00:00:00Z"
+        stream.earliest_state = "2024-06-01T00:00:00Z"
+        stream.more_items_in_collection = True
+        row = {"update_time": "2024-06-01T00:00:00.000000Z"}
+        result = stream.write_record(row)
+        self.assertTrue(result)
+        self.assertTrue(stream.more_items_in_collection)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -328,11 +328,25 @@ class TestPipedriveIncrementalStreamUsingSortWriteRecord(unittest.TestCase):
         """write_record returns False and sets more_items_in_collection=False for old records."""
         stream = _SimpleIncrementalSortStream()
         stream.initial_state = "2024-06-01T00:00:00Z"
+        stream.earliest_state = "2024-06-01T00:00:00Z"
         stream.more_items_in_collection = True
         row = {"update_time": "2024-01-01T00:00:00Z"}
         result = stream.write_record(row)
         self.assertFalse(result)
         self.assertFalse(stream.more_items_in_collection)
+
+    def test_commits_max_seen_bookmark_when_stopping_early(self):
+        """write_record commits _max_seen_bookmark to earliest_state on early stop."""
+        stream = _SimpleIncrementalSortStream()
+        stream.initial_state = "2024-01-01T00:00:00Z"
+        stream.earliest_state = "2024-01-01T00:00:00Z"
+        stream._max_seen_bookmark = "2024-06-01T00:00:00Z"
+        stream.more_items_in_collection = True
+        # A row older than initial_state triggers the early stop
+        row = {"update_time": "2023-12-01T00:00:00.000000Z"}
+        result = stream.write_record(row)
+        self.assertFalse(result)
+        self.assertEqual(stream.earliest_state, "2024-06-01T00:00:00Z")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -1,0 +1,426 @@
+"""
+Unit tests for tap_pipedrive.stream module.
+
+Covers: PipedriveStream, PipedriveV1IncrementalStream, RecentsStream,
+        PipedriveIncrementalStreamUsingSort, PipedriveIterStream.find_deal_ids
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pendulum
+
+from tap_pipedrive.stream import (
+    PipedriveStream,
+    PipedriveV1IncrementalStream,
+    RecentsStream,
+    PipedriveIncrementalStreamUsingSort,
+    PipedriveIterStream,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclasses (PipedriveStream is not abstract, but its schema
+# and state_field must be set to test most methods meaningfully)
+# ---------------------------------------------------------------------------
+
+class _SimpleStream(PipedriveStream):
+    schema = "test_stream"
+    state_field = "update_time"
+    key_properties = ["id"]
+    schema_path = "schemas/deals.json"  # reuse any real schema to avoid file errors
+
+
+class _SimpleV1Stream(PipedriveV1IncrementalStream):
+    schema = "test_v1_stream"
+    state_field = "update_time"
+    key_properties = ["id"]
+    schema_path = "schemas/activities.json"
+
+
+class _SimpleIncrementalSortStream(PipedriveIncrementalStreamUsingSort):
+    schema = "test_sort_stream"
+    state_field = "update_time"
+    key_properties = ["id"]
+    schema_path = "schemas/deals.json"
+
+
+class _SimpleIterStream(PipedriveIterStream):
+    schema = "dealflow"
+    state_field = "log_time"
+    key_properties = ["id"]
+    base_endpoint = "deals"
+    schema_path = "schemas/dealflow.json"
+
+
+class _SimpleRecentsStream(RecentsStream):
+    schema = "activities"
+    state_field = "update_time"
+    key_properties = ["id"]
+    items = "activity"
+    schema_path = "schemas/activities.json"
+    recent_endpoint = "recents"
+    endpoint = "activities"
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveStreamHasData
+# ---------------------------------------------------------------------------
+
+class TestPipedriveStreamHasData(unittest.TestCase):
+    """Verify has_data delegates to more_items_in_collection."""
+
+    def test_has_data_true_when_more_items(self):
+        """has_data returns True when more_items_in_collection is True."""
+        stream = _SimpleStream()
+        stream.more_items_in_collection = True
+        self.assertTrue(stream.has_data())
+
+    def test_has_data_false_when_no_more_items(self):
+        """has_data returns False when more_items_in_collection is False."""
+        stream = _SimpleStream()
+        stream.more_items_in_collection = False
+        self.assertFalse(stream.has_data())
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveStreamSetInitialState
+# ---------------------------------------------------------------------------
+
+class TestPipedriveStreamSetInitialState(unittest.TestCase):
+    """Verify set_initial_state reads bookmark or falls back to start_date."""
+
+    def test_uses_bookmark_when_present(self):
+        """set_initial_state uses the bookmark value from state when available."""
+        stream = _SimpleStream()
+        state = {"bookmarks": {"test_stream": {"update_time": "2024-06-01T00:00:00Z"}}}
+        stream.set_initial_state(state, "2024-01-01T00:00:00Z")
+        self.assertEqual(stream.initial_state, "2024-06-01T00:00:00Z")
+        self.assertEqual(stream.earliest_state, "2024-06-01T00:00:00Z")
+
+    def test_falls_back_to_start_date_when_no_bookmark(self):
+        """set_initial_state falls back to start_date when no bookmark exists."""
+        stream = _SimpleStream()
+        state = {"bookmarks": {}}
+        stream.set_initial_state(state, "2024-01-01T00:00:00Z")
+        self.assertEqual(stream.initial_state, "2024-01-01T00:00:00Z")
+
+    def test_falls_back_to_start_date_when_state_empty(self):
+        """set_initial_state falls back to start_date when state is empty."""
+        stream = _SimpleStream()
+        stream.set_initial_state({}, "2024-01-01T00:00:00Z")
+        self.assertEqual(stream.initial_state, "2024-01-01T00:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveStreamUpdateState
+# ---------------------------------------------------------------------------
+
+class TestPipedriveStreamUpdateState(unittest.TestCase):
+    """Verify update_state advances earliest_state when a newer record arrives."""
+
+    def test_updates_earliest_state_when_row_is_newer(self):
+        """update_state advances earliest_state when the record's timestamp is newer."""
+        stream = _SimpleStream()
+        stream.earliest_state = "2024-01-01T00:00:00Z"
+        row = {"update_time": "2024-06-01T00:00:00.000000Z"}
+        stream.update_state(row)
+        self.assertEqual(stream.earliest_state, "2024-06-01T00:00:00Z")
+
+    def test_does_not_update_when_row_is_older(self):
+        """update_state does not change earliest_state when the record is older."""
+        stream = _SimpleStream()
+        stream.earliest_state = "2024-06-01T00:00:00Z"
+        row = {"update_time": "2024-01-01T00:00:00.000000Z"}
+        stream.update_state(row)
+        self.assertEqual(stream.earliest_state, "2024-06-01T00:00:00Z")
+
+    def test_does_not_update_when_state_field_missing(self):
+        """update_state does not raise and leaves earliest_state unchanged when field is absent."""
+        stream = _SimpleStream()
+        stream.earliest_state = "2024-01-01T00:00:00Z"
+        row = {}
+        stream.update_state(row)
+        self.assertEqual(stream.earliest_state, "2024-01-01T00:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveStreamWriteRecord
+# ---------------------------------------------------------------------------
+
+class TestPipedriveStreamWriteRecord(unittest.TestCase):
+    """Verify write_record filters records based on initial_state."""
+
+    def test_returns_true_when_no_state_field_in_row(self):
+        """write_record returns True when the row does not contain the state_field."""
+        stream = _SimpleStream()
+        stream.initial_state = "2024-01-01T00:00:00Z"
+        self.assertTrue(stream.write_record({}))
+
+    def test_returns_true_when_record_is_at_or_after_initial_state(self):
+        """write_record returns True when record's replication key >= initial_state."""
+        stream = _SimpleStream()
+        stream.initial_state = "2024-01-01T00:00:00Z"
+        row = {"update_time": "2024-06-01T00:00:00Z"}
+        self.assertTrue(stream.write_record(row))
+
+    def test_returns_false_when_record_is_before_initial_state(self):
+        """write_record returns False when record's replication key < initial_state."""
+        stream = _SimpleStream()
+        stream.initial_state = "2024-06-01T00:00:00Z"
+        row = {"update_time": "2024-01-01T00:00:00Z"}
+        self.assertFalse(stream.write_record(row))
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveStreamPaginate (cursor-based)
+# ---------------------------------------------------------------------------
+
+class TestPipedriveStreamPaginate(unittest.TestCase):
+    """Verify cursor-based paginate correctly advances the cursor."""
+
+    def _make_response(self, next_cursor=None):
+        payload = {"additional_data": {}}
+        if next_cursor:
+            payload["additional_data"]["next_cursor"] = next_cursor
+        resp = MagicMock()
+        resp.json.return_value = payload
+        return resp
+
+    def test_sets_cursor_and_more_items_when_next_cursor_present(self):
+        """paginate sets cursor and more_items_in_collection=True when next_cursor is returned."""
+        stream = _SimpleStream()
+        stream.more_items_in_collection = False
+        resp = self._make_response(next_cursor="abc123")
+        stream.paginate(resp)
+        self.assertEqual(stream.cursor, "abc123")
+        self.assertTrue(stream.more_items_in_collection)
+
+    def test_clears_more_items_when_no_next_cursor(self):
+        """paginate sets more_items_in_collection=False when no next_cursor is returned."""
+        stream = _SimpleStream()
+        stream.more_items_in_collection = True
+        resp = self._make_response(next_cursor=None)
+        stream.paginate(resp)
+        self.assertFalse(stream.more_items_in_collection)
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveV1IncrementalStreamPaginate (page-based)
+# ---------------------------------------------------------------------------
+
+class TestPipedriveV1IncrementalStreamPaginate(unittest.TestCase):
+    """Verify V1 page-based paginate advances start offset correctly."""
+
+    def _make_response(self, more_items, next_start=None):
+        pagination = {"more_items_in_collection": more_items}
+        if next_start is not None:
+            pagination["next_start"] = next_start
+        payload = {"additional_data": {"pagination": pagination}}
+        resp = MagicMock()
+        resp.json.return_value = payload
+        return resp
+
+    def test_advances_start_when_more_items_present(self):
+        """V1 paginate advances start offset when more pages are available."""
+        stream = _SimpleV1Stream()
+        resp = self._make_response(more_items=True, next_start=100)
+        stream.paginate(resp)
+        self.assertTrue(stream.more_items_in_collection)
+        self.assertEqual(stream.start, 100)
+
+    def test_stops_when_no_more_items(self):
+        """V1 paginate sets more_items_in_collection=False when no more pages exist."""
+        stream = _SimpleV1Stream()
+        stream.more_items_in_collection = True
+        resp = self._make_response(more_items=False)
+        stream.paginate(resp)
+        self.assertFalse(stream.more_items_in_collection)
+
+    def test_stops_when_no_pagination_key_in_additional_data(self):
+        """V1 paginate stops when 'pagination' key is absent from additional_data."""
+        stream = _SimpleV1Stream()
+        stream.more_items_in_collection = True
+        resp = MagicMock()
+        resp.json.return_value = {"additional_data": {}}
+        stream.paginate(resp)
+        self.assertFalse(stream.more_items_in_collection)
+
+
+# ---------------------------------------------------------------------------
+# TestRecentsStreamUpdateRequestParams
+# ---------------------------------------------------------------------------
+
+class TestRecentsStreamUpdateRequestParams(unittest.TestCase):
+    """Verify RecentsStream switches to /recents endpoint for recent data."""
+
+    def test_uses_recents_endpoint_when_initial_state_within_one_month(self):
+        """update_request_params uses recents endpoint when initial_state is within the last month."""
+        stream = _SimpleRecentsStream()
+        recent_date = pendulum.now().subtract(days=7).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stream.initial_state = recent_date
+        stream.cursor = None
+        params = stream.update_request_params({})
+        self.assertEqual(stream.endpoint, "recents")
+        self.assertIn("since_timestamp", params)
+        self.assertIn("items", params)
+
+    def test_uses_base_endpoint_when_initial_state_older_than_one_month(self):
+        """update_request_params falls back to the base endpoint for old initial_state."""
+        stream = _SimpleRecentsStream()
+        old_date = pendulum.now().subtract(months=3).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stream.initial_state = old_date
+        stream.cursor = None
+        # endpoint should NOT be switched to recents
+        stream.endpoint = "activities"  # reset
+        params = stream.update_request_params({})
+        self.assertNotEqual(stream.endpoint, "recents")
+
+
+# ---------------------------------------------------------------------------
+# TestRecentsStreamProcessRow
+# ---------------------------------------------------------------------------
+
+class TestRecentsStreamProcessRow(unittest.TestCase):
+    """Verify RecentsStream.process_row unwraps /recents nested data correctly."""
+
+    def test_process_row_on_recents_endpoint_returns_data_dict(self):
+        """process_row returns the nested 'data' dict when endpoint is 'recents'."""
+        stream = _SimpleRecentsStream()
+        stream.endpoint = "recents"
+        row = {"data": {"id": 1, "name": "Test"}, "object": "activity"}
+        result = stream.process_row(row)
+        self.assertEqual(result, {"id": 1, "name": "Test"})
+
+    def test_process_row_on_recents_endpoint_with_list_data_returns_first(self):
+        """process_row returns the first element when 'data' is a list."""
+        stream = _SimpleRecentsStream()
+        stream.endpoint = "recents"
+        row = {"data": [{"id": 2}, {"id": 3}], "object": "activity"}
+        result = stream.process_row(row)
+        self.assertEqual(result, {"id": 2})
+
+    def test_process_row_on_base_endpoint_returns_row_as_is(self):
+        """process_row returns the row unchanged when not using the recents endpoint."""
+        stream = _SimpleRecentsStream()
+        stream.endpoint = "activities"
+        row = {"id": 5, "name": "Direct"}
+        result = stream.process_row(row)
+        self.assertEqual(result, row)
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveIncrementalStreamUsingSortWriteRecord
+# ---------------------------------------------------------------------------
+
+class TestPipedriveIncrementalStreamUsingSortWriteRecord(unittest.TestCase):
+    """Verify descending-sort stream stops fetching once records go below bookmark."""
+
+    def test_returns_true_for_records_at_or_after_initial_state(self):
+        """write_record returns True when replication key >= initial_state."""
+        stream = _SimpleIncrementalSortStream()
+        stream.initial_state = "2024-01-01T00:00:00Z"
+        stream.more_items_in_collection = True
+        row = {"update_time": "2024-06-01T00:00:00Z"}
+        self.assertTrue(stream.write_record(row))
+        self.assertTrue(stream.more_items_in_collection)
+
+    def test_returns_false_and_stops_pagination_for_old_records(self):
+        """write_record returns False and sets more_items_in_collection=False for old records."""
+        stream = _SimpleIncrementalSortStream()
+        stream.initial_state = "2024-06-01T00:00:00Z"
+        stream.more_items_in_collection = True
+        row = {"update_time": "2024-01-01T00:00:00Z"}
+        result = stream.write_record(row)
+        self.assertFalse(result)
+        self.assertFalse(stream.more_items_in_collection)
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveIncrementalStreamUsingSortUpdateState
+# ---------------------------------------------------------------------------
+
+class TestPipedriveIncrementalStreamUsingSortUpdateState(unittest.TestCase):
+    """Verify descending-sort stream only updates state after all pages are consumed."""
+
+    def test_does_not_update_state_while_more_items_remain(self):
+        """update_state does not advance earliest_state while more_items_in_collection is True."""
+        stream = _SimpleIncrementalSortStream()
+        stream.earliest_state = "2024-01-01T00:00:00Z"
+        stream.more_items_in_collection = True
+        row = {"update_time": "2024-06-01T00:00:00.000000Z"}
+        stream.update_state(row)
+        self.assertEqual(stream.earliest_state, "2024-01-01T00:00:00Z")
+
+    def test_updates_state_when_no_more_items(self):
+        """update_state advances earliest_state once all pages are fetched."""
+        stream = _SimpleIncrementalSortStream()
+        stream.earliest_state = "2024-01-01T00:00:00Z"
+        stream.more_items_in_collection = False
+        row = {"update_time": "2024-06-01T00:00:00.000000Z"}
+        stream.update_state(row)
+        self.assertEqual(stream.earliest_state, "2024-06-01T00:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# TestPipedriveIterStreamFindDealIds
+# ---------------------------------------------------------------------------
+
+class TestPipedriveIterStreamFindDealIds(unittest.TestCase):
+    """Verify find_deal_ids correctly identifies added and stage-changed deals."""
+
+    def _stream(self):
+        stream = _SimpleIterStream()
+        return stream
+
+    def _record(self, deal_id, add_time, stage_change_time=None):
+        return {
+            "id": deal_id,
+            "add_time": add_time,
+            "stage_change_time": stage_change_time,
+            "update_time": add_time,
+        }
+
+    def test_returns_deal_id_when_added_within_window(self):
+        """find_deal_ids includes deals added within the start/stop window."""
+        stream = self._stream()
+        data = [self._record(1, "2024-03-01T00:00:00Z")]
+        result = stream.find_deal_ids(data, start="2024-01-01T00:00:00Z", stop="2024-06-01T00:00:00Z")
+        self.assertIn(1, result)
+
+    def test_excludes_deal_added_before_window(self):
+        """find_deal_ids excludes deals added before the start of the window."""
+        stream = self._stream()
+        data = [self._record(2, "2023-01-01T00:00:00Z")]
+        result = stream.find_deal_ids(data, start="2024-01-01T00:00:00Z", stop="2024-06-01T00:00:00Z")
+        self.assertNotIn(2, result)
+
+    def test_includes_deal_with_stage_change_within_window(self):
+        """find_deal_ids includes deals with a stage_change_time within the window."""
+        stream = self._stream()
+        data = [self._record(3, "2023-01-01T00:00:00Z", stage_change_time="2024-03-01T00:00:00Z")]
+        result = stream.find_deal_ids(data, start="2024-01-01T00:00:00Z", stop="2024-06-01T00:00:00Z")
+        self.assertIn(3, result)
+
+    def test_excludes_deal_with_stage_change_outside_window(self):
+        """find_deal_ids excludes deals whose stage_change_time falls outside the window."""
+        stream = self._stream()
+        data = [self._record(4, "2023-01-01T00:00:00Z", stage_change_time="2023-06-01T00:00:00Z")]
+        result = stream.find_deal_ids(data, start="2024-01-01T00:00:00Z", stop="2024-06-01T00:00:00Z")
+        self.assertNotIn(4, result)
+
+    def test_no_duplicates_when_deal_added_and_has_stage_change(self):
+        """find_deal_ids does not duplicate a deal that both was added and had a stage change."""
+        stream = self._stream()
+        data = [self._record(5, "2024-03-01T00:00:00Z", stage_change_time="2024-04-01T00:00:00Z")]
+        result = stream.find_deal_ids(data, start="2024-01-01T00:00:00Z", stop="2024-06-01T00:00:00Z")
+        self.assertEqual(result.count(5), 1)
+
+    def test_empty_data_returns_empty_list(self):
+        """find_deal_ids returns an empty list when given no records."""
+        stream = self._stream()
+        result = stream.find_deal_ids([], start="2024-01-01T00:00:00Z", stop="2024-06-01T00:00:00Z")
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_tap.py
+++ b/tests/unittests/test_tap.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for tap_pipedrive.tap module.
+
+Covers: do_discover, iterate_response, validate_response, rate_throttling,
+        get_selected_streams, raise_for_error (5xx catch-all), do_paginate.
+"""
+import time
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import requests
+
+from tap_pipedrive.tap import PipedriveTap, raise_for_error
+from tap_pipedrive.exceptions import (
+    PipedriveBadRequestError,
+    PipedriveUnauthorizedError,
+    PipedrivePaymentRequiredError,
+    PipedriveForbiddenError,
+    PipedriveNotFoundError,
+    PipedriveGoneError,
+    PipedriveUnsupportedMediaError,
+    PipedriveUnprocessableEntityError,
+    PipedriveTooManyRequestsError,
+    PipedriveTooManyRequestsInSecondError,
+    PipedriveInternalServiceError,
+    PipedriveNotImplementedError,
+    PipedriveServiceUnavailableError,
+    Pipedrive5xxError,
+    PipedriveError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**kwargs):
+    base = {"api_token": "test_token", "start_date": "2024-01-01T00:00:00Z"}
+    base.update(kwargs)
+    return base
+
+
+def _make_response(status_code, json_body=None, headers=None, raise_exc=None):
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.url = "https://api.pipedrive.com/api/v2/test"
+    resp.text = str(json_body)
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("no body")
+    if raise_exc:
+        resp.raise_for_status.side_effect = raise_exc
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_http_error(status_code, json_body=None, headers=None):
+    """Build an HTTPError with an attached response mock."""
+    resp = _make_response(status_code, json_body=json_body, headers=headers)
+    err = requests.HTTPError(response=resp)
+    err.response = resp
+    resp.raise_for_status.side_effect = err
+    return resp
+
+
+def _make_tap():
+    return PipedriveTap(_make_config(), {})
+
+
+# ---------------------------------------------------------------------------
+# TestIterateResponse
+# ---------------------------------------------------------------------------
+
+class TestIterateResponse(unittest.TestCase):
+    """Verify iterate_response correctly handles null and non-null payloads."""
+
+    def test_null_data_returns_empty_list(self):
+        """iterate_response yields [] when payload['data'] is None."""
+        tap = _make_tap()
+        resp = _make_response(200, json_body={"data": None})
+        result = tap.iterate_response(resp)
+        self.assertEqual(result, [])
+
+    def test_non_null_data_returns_records(self):
+        """iterate_response yields the data list when payload contains records."""
+        tap = _make_tap()
+        records = [{"id": 1}, {"id": 2}]
+        resp = _make_response(200, json_body={"data": records})
+        result = tap.iterate_response(resp)
+        self.assertEqual(result, records)
+
+
+# ---------------------------------------------------------------------------
+# TestValidateResponse
+# ---------------------------------------------------------------------------
+
+class TestValidateResponse(unittest.TestCase):
+    """Verify validate_response returns True for valid Singer payloads."""
+
+    def test_valid_success_payload_returns_true(self):
+        """validate_response returns True when 'success' is True and 'data' is present."""
+        tap = _make_tap()
+        resp = _make_response(200, json_body={"success": True, "data": [{"id": 1}]})
+        self.assertTrue(tap.validate_response(resp))
+
+    def test_success_false_returns_none(self):
+        """validate_response returns None when 'success' is False."""
+        tap = _make_tap()
+        resp = _make_response(200, json_body={"success": False, "data": []})
+        self.assertIsNone(tap.validate_response(resp))
+
+    def test_missing_data_key_returns_none(self):
+        """validate_response returns None when 'data' key is absent."""
+        tap = _make_tap()
+        resp = _make_response(200, json_body={"success": True})
+        self.assertIsNone(tap.validate_response(resp))
+
+
+# ---------------------------------------------------------------------------
+# TestRateThrottling
+# ---------------------------------------------------------------------------
+
+class TestRateThrottling(unittest.TestCase):
+    """Verify rate_throttling sleeps correctly when rate-limit headers are present."""
+
+    @patch("tap_pipedrive.tap.time.sleep")
+    def test_sleeps_when_remaining_is_zero(self, mock_sleep):
+        """rate_throttling sleeps for X-RateLimit-Reset seconds when remaining < 1."""
+        tap = _make_tap()
+        resp = _make_response(
+            200,
+            headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "5"},
+        )
+        tap.rate_throttling(resp)
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("tap_pipedrive.tap.time.sleep")
+    def test_no_sleep_when_remaining_above_zero(self, mock_sleep):
+        """rate_throttling does not sleep when X-RateLimit-Remaining >= 1."""
+        tap = _make_tap()
+        resp = _make_response(
+            200,
+            headers={"X-RateLimit-Remaining": "10", "X-RateLimit-Reset": "5"},
+        )
+        tap.rate_throttling(resp)
+        mock_sleep.assert_not_called()
+
+    @patch("tap_pipedrive.tap.time.sleep")
+    def test_no_sleep_when_headers_absent(self, mock_sleep):
+        """rate_throttling does not sleep when rate-limit headers are missing."""
+        tap = _make_tap()
+        resp = _make_response(200, headers={})
+        tap.rate_throttling(resp)
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestGetSelectedStreams
+# ---------------------------------------------------------------------------
+
+class TestGetSelectedStreams(unittest.TestCase):
+    """Verify get_selected_streams filters according to catalog metadata."""
+
+    def _make_catalog_stream(self, tap_stream_id, selected):
+        stream = MagicMock()
+        stream.tap_stream_id = tap_stream_id
+        stream.metadata = [{"breadcrumb": [], "metadata": {"selected": selected}}]
+        return stream
+
+    def test_returns_selected_streams(self):
+        """get_selected_streams returns only streams marked as selected=True."""
+        tap = _make_tap()
+        catalog = MagicMock()
+        catalog.streams = [
+            self._make_catalog_stream("deals", True),
+            self._make_catalog_stream("activities", False),
+            self._make_catalog_stream("users", True),
+        ]
+        result = tap.get_selected_streams(catalog)
+        self.assertIn("deals", result)
+        self.assertIn("users", result)
+        self.assertNotIn("activities", result)
+
+    def test_returns_empty_when_none_selected(self):
+        """get_selected_streams returns an empty list when no streams are selected."""
+        tap = _make_tap()
+        catalog = MagicMock()
+        catalog.streams = [
+            self._make_catalog_stream("deals", False),
+        ]
+        result = tap.get_selected_streams(catalog)
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# TestRaiseForError
+# ---------------------------------------------------------------------------
+
+class TestRaiseForError(unittest.TestCase):
+    """Verify raise_for_error maps HTTP status codes to the correct exceptions."""
+
+    def _call(self, status_code, json_body=None, headers=None):
+        resp = _make_http_error(status_code, json_body=json_body, headers=headers)
+        raise_for_error(resp)
+
+    def test_400_raises_bad_request(self):
+        """raise_for_error raises PipedriveBadRequestError on HTTP 400."""
+        with self.assertRaises(PipedriveBadRequestError):
+            self._call(400, json_body={"error": "bad input"})
+
+    def test_401_raises_unauthorized(self):
+        """raise_for_error raises PipedriveUnauthorizedError on HTTP 401."""
+        with self.assertRaises(PipedriveUnauthorizedError):
+            self._call(401, json_body={})
+
+    def test_402_raises_payment_required(self):
+        """raise_for_error raises PipedrivePaymentRequiredError on HTTP 402."""
+        with self.assertRaises(PipedrivePaymentRequiredError):
+            self._call(402, json_body={})
+
+    def test_403_raises_forbidden(self):
+        """raise_for_error raises PipedriveForbiddenError on HTTP 403."""
+        with self.assertRaises(PipedriveForbiddenError):
+            self._call(403, json_body={})
+
+    def test_404_raises_not_found(self):
+        """raise_for_error raises PipedriveNotFoundError on HTTP 404."""
+        with self.assertRaises(PipedriveNotFoundError):
+            self._call(404, json_body={})
+
+    def test_410_raises_gone(self):
+        """raise_for_error raises PipedriveGoneError on HTTP 410."""
+        with self.assertRaises(PipedriveGoneError):
+            self._call(410, json_body={})
+
+    def test_415_raises_unsupported_media(self):
+        """raise_for_error raises PipedriveUnsupportedMediaError on HTTP 415."""
+        with self.assertRaises(PipedriveUnsupportedMediaError):
+            self._call(415, json_body={})
+
+    def test_422_raises_unprocessable_entity(self):
+        """raise_for_error raises PipedriveUnprocessableEntityError on HTTP 422."""
+        with self.assertRaises(PipedriveUnprocessableEntityError):
+            self._call(422, json_body={})
+
+    def test_500_raises_internal_service_error(self):
+        """raise_for_error raises PipedriveInternalServiceError on HTTP 500."""
+        with self.assertRaises(PipedriveInternalServiceError):
+            self._call(500, json_body={})
+
+    def test_501_raises_not_implemented(self):
+        """raise_for_error raises PipedriveNotImplementedError on HTTP 501."""
+        with self.assertRaises(PipedriveNotImplementedError):
+            self._call(501, json_body={})
+
+    def test_503_raises_service_unavailable(self):
+        """raise_for_error raises PipedriveServiceUnavailableError on HTTP 503."""
+        with self.assertRaises(PipedriveServiceUnavailableError):
+            self._call(503, json_body={})
+
+    def test_5xx_catchall_raises_pipedrive5xx_error(self):
+        """raise_for_error raises Pipedrive5xxError for unlisted 5xx codes (e.g. 524)."""
+        with self.assertRaises(Pipedrive5xxError):
+            self._call(524, json_body={})
+
+    def test_error_message_includes_status_code(self):
+        """raise_for_error includes the HTTP status code in the exception message."""
+        with self.assertRaises(PipedriveNotFoundError) as ctx:
+            self._call(404, json_body={})
+        self.assertIn("404", str(ctx.exception))
+
+    def test_429_rate_limit_per_second_raises_too_many_requests_in_second(self):
+        """raise_for_error raises PipedriveTooManyRequestsInSecondError when X-RateLimit-Remaining is 0."""
+        with self.assertRaises(PipedriveTooManyRequestsInSecondError):
+            self._call(
+                429,
+                json_body={},
+                headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "2"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestDiscover
+# ---------------------------------------------------------------------------
+
+_MOCK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "id": {"type": ["null", "integer"]},
+        "update_time": {"type": ["null", "string"]},
+        "log_time": {"type": ["null", "string"]},
+        "add_time": {"type": ["null", "string"]},
+        "modified": {"type": ["null", "string"]},
+    },
+}
+
+
+class TestDiscover(unittest.TestCase):
+    """Verify do_discover builds a valid Singer Catalog."""
+
+    @patch("tap_pipedrive.stream.DynamicSchemaStream.get_schema", return_value=_MOCK_SCHEMA)
+    @patch("tap_pipedrive.stream.PipedriveStream.get_schema", return_value=_MOCK_SCHEMA)
+    def test_discover_returns_catalog_with_all_streams(self, mock_base, mock_dyn):
+        """do_discover returns a Catalog containing an entry for every configured stream."""
+        tap = _make_tap()
+        catalog = tap.do_discover()
+        stream_ids = [s.tap_stream_id for s in catalog.streams]
+        self.assertIn("deals", stream_ids)
+        self.assertIn("users", stream_ids)
+        self.assertIn("activities", stream_ids)
+
+    @patch("tap_pipedrive.stream.DynamicSchemaStream.get_schema", return_value=_MOCK_SCHEMA)
+    @patch("tap_pipedrive.stream.PipedriveStream.get_schema", return_value=_MOCK_SCHEMA)
+    def test_discover_sets_key_properties(self, mock_base, mock_dyn):
+        """do_discover attaches the correct key_properties to each catalog entry."""
+        tap = _make_tap()
+        catalog = tap.do_discover()
+        deals_entry = next(s for s in catalog.streams if s.tap_stream_id == "deals")
+        self.assertEqual(deals_entry.key_properties, ["id"])
+
+    @patch("tap_pipedrive.stream.DynamicSchemaStream.get_schema", return_value=_MOCK_SCHEMA)
+    @patch("tap_pipedrive.stream.PipedriveStream.get_schema", return_value=_MOCK_SCHEMA)
+    def test_discover_incremental_stream_has_replication_key_in_metadata(self, mock_base, mock_dyn):
+        """do_discover marks the replication key as automatic for incremental streams."""
+        from singer import metadata
+        tap = _make_tap()
+        catalog = tap.do_discover()
+        deals_entry = next(s for s in catalog.streams if s.tap_stream_id == "deals")
+        mdata = metadata.to_map(deals_entry.metadata)
+        from tap_pipedrive.streams.deals import DealsStream
+        deals_stream = DealsStream()
+        if deals_stream.state_field:
+            self.assertEqual(
+                mdata.get(("properties", deals_stream.state_field), {}).get("inclusion"),
+                "automatic",
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestDoPaginate
+# ---------------------------------------------------------------------------
+
+class TestDoPaginate(unittest.TestCase):
+    """Verify do_paginate writes schema, records, and state correctly."""
+
+    def _build_stream_and_catalog(self, schema_name="currencies"):
+        """Build a minimal stream + catalog metadata mock for do_paginate."""
+        from tap_pipedrive.streams.currencies import CurrenciesStream
+        stream = CurrenciesStream()
+        stream.tap = None  # will be set by tap
+
+        catalog_stream = MagicMock()
+        catalog_stream.metadata = [{"breadcrumb": [], "metadata": {}}]
+        catalog = MagicMock()
+        catalog.get_stream.return_value = catalog_stream
+        return stream, catalog
+
+    @patch("singer.write_state")
+    @patch("singer.write_record")
+    @patch("singer.write_bookmark", side_effect=lambda state, *a, **kw: state)
+    @patch("tap_pipedrive.tap.PipedriveTap.execute_stream_request")
+    def test_do_paginate_writes_records(
+        self, mock_exec, mock_bookmark, mock_write_record, mock_write_state
+    ):
+        """do_paginate calls singer.write_record for every row returned by the API."""
+        tap = _make_tap()
+        stream, catalog = self._build_stream_and_catalog()
+        stream.tap = tap
+
+        records = [{"id": 1, "name": "USD"}, {"id": 2, "name": "EUR"}]
+        page1 = _make_response(
+            200,
+            json_body={"success": True, "data": records, "additional_data": {}},
+            headers={"X-RateLimit-Remaining": "10"},
+        )
+        # First call returns data; second call: stream.has_data() returns False after paginate
+        mock_exec.return_value = page1
+
+        stream.more_items_in_collection = True
+        stream.initial_state = "2024-01-01T00:00:00Z"
+
+        tap.do_paginate(stream, {})
+
+        self.assertEqual(mock_write_record.call_count, len(records))
+
+    @patch("singer.write_state")
+    @patch("singer.write_record")
+    @patch("singer.write_bookmark", side_effect=lambda state, *a, **kw: state)
+    @patch("tap_pipedrive.tap.PipedriveTap.execute_stream_request")
+    def test_do_paginate_with_empty_data_writes_no_records(
+        self, mock_exec, mock_bookmark, mock_write_record, mock_write_state
+    ):
+        """do_paginate writes no records when the API returns an empty data list."""
+        tap = _make_tap()
+        stream, catalog = self._build_stream_and_catalog()
+        stream.tap = tap
+
+        page = _make_response(
+            200,
+            json_body={"success": True, "data": [], "additional_data": {}},
+            headers={"X-RateLimit-Remaining": "10"},
+        )
+        mock_exec.return_value = page
+        stream.more_items_in_collection = True
+        stream.initial_state = "2024-01-01T00:00:00Z"
+
+        tap.do_paginate(stream, {})
+
+        mock_write_record.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description of change
[(JIRA)](https://qlik-dev.atlassian.net/browse/SAC-28764)

## Summary

Bug fixes and robustness improvements for incremental sync correctness, plus dependency upgrades.

---

## Changes

### Timestamp normalization (`tap_pipedrive/stream.py`)

**Root cause fixed:** `write_record()` and `update_state()` compared raw Pipedrive API timestamps against stored bookmarks as plain strings. Pipedrive rows carry microseconds (e.g. `"2024-06-01T10:20:30.000000Z"`) while bookmarks are stored at second precision (`"2024-06-01T10:20:30Z"`). Lexicographically, `.` (ASCII 46) < `Z` (ASCII 90), so a record at the *same* second as the bookmark was incorrectly seen as older, causing pagination to stop early and records to be silently skipped.

- Added `_normalize_bookmark(value)` static method on `PipedriveStream` — single shared helper that strips fractional seconds via `strptime("%fZ")` → `strftime("Z")`, passing through already-normalized or unrecognized values unchanged
- `PipedriveStream.write_record`: normalizes row replication-key value before comparing with `initial_state`
- `PipedriveStream.update_state`: uses `_normalize_bookmark` instead of inline `strptime` with hardcoded `.000000Z` pattern (now handles any sub-second precision)
- `PipedriveStream.set_initial_state`: uses `_normalize_bookmark` to strip microseconds from bookmarks read from state, replacing the previous `try/except strptime` block
- `PipedriveIncrementalStreamUsingSort.write_record`: normalizes row value before comparison; on early-stop now commits `_max_seen_bookmark` to `earliest_state` immediately (since `update_state` won't be called for that row)
- `PipedriveIncrementalStreamUsingSort.update_state`: replaced early-return `if self.more_items_in_collection: return` pattern with a running-max tracker (`_max_seen_bookmark`) committed to `earliest_state` only when pagination is complete — prevents committing a stale (non-maximum) bookmark when sync is interrupted mid-page
- `PipedriveIncrementalStreamUsingSort.set_initial_state`: calls `super()` then resets `_max_seen_bookmark = None` to ensure a clean slate per sync

### Dependency upgrades (`setup.py`)

| Package | Before | After |
|---|---|---|
| `pendulum` | `3.1.0` | `3.2.0` |
| `requests` | `2.32.4` | `2.33.1` |
| `singer-python` | `6.1.1` | `6.8.0` |

---

## Tests

| File | Coverage added |
|---|---|
| `tests/unittests/test_stream.py` | 40 tests across all stream classes: `_normalize_bookmark` (5), `set_initial_state` (6), `update_state` (5), `write_record` (5 base + 4 sort including 2 microsecond regression cases), `paginate` cursor + V1 (5), `RecentsStream` (5), `PipedriveIterStream.find_deal_ids` (6) |
| `tests/unittests/test_tap.py` | 417-line new test file covering tap-level behaviour |
| `tests/test_pipedrive_bookmarks.py` | Dynamic simulated states (median replication-key from first sync); microsecond normalization before storing in state |
| `tests/test_pipedrive_start_date.py` | `start_date_2` updated to `"2026-04-25T00:00:00Z"` to post-date seeded data |

# Manual QA steps
---

## Test Setup

| Step | Action |
|---|---|
| 1 | Seeded Pipedrive test account using `spike/seed_pipedrive.py` from main branch |
| 2 | Ran full sync (`out1.json`) — no state file |
| 3 | Extracted final STATE message from `out1.json` → `state.json` |
| 4 | Ran incremental sync (`out2.json`) — using `state.json` in this branch |
| 5 | Compared record counts and bookmarks between both runs |

---

## Record Count Comparison

| Stream | out1 (full) | out2 (incremental) | Result |
|---|---|---|---|
| `activities` | 170 | 2 | ✅ Only new/updated records |
| `activity_types` | 10 | 8 | ✅ Only updated records |
| `currency` | 186 | 186 | ✅ FULL_TABLE — expected same count |
| `deal_fields` | 48 | 48 | ℹ️ Bookmark stuck at `2020-01-01` — always replicated fully |
| `deal_products` | 112 | 1 | ✅ Only new records |
| `dealflow` | 222 | 0 | ✅ No new events since bookmark |
| `deals` | 170 | 1 | ✅ Only new/updated records |
| `files` | 16 | 0 | ✅ No changes since bookmark |
| `filters` | 48 | 48 | ℹ️ Bookmark stuck at `2020-01-01` — always replicated fully |
| `notes` | 169 | 103 | ✅ Only records updated after bookmark |
| `organizations` | 170 | 1 | ✅ Only new/updated records |
| `persons` | 170 | 1 | ✅ Only new/updated records |
| `pipelines` | 5 | 2 | ✅ Only updated records |
| `products` | 3 | 1 | ✅ Only updated records |
| `stages` | 26 | 2 | ✅ Only updated records |
| `users` | 1 | 0 | ✅ No changes since bookmark |

---

## Bookmark Progression

| Stream | Bookmark key | after out1 | after out2 | Status |
|---|---|---|---|---|
| `activities` | `update_time` | `2026-04-24T05:58:20Z` | `2026-04-24T05:58:20Z` | — same |
| `activity_types` | `update_time` | `2026-04-24T05:50:04Z` | `2026-04-24T05:50:04Z` | — same |
| `deal_fields` | `update_time` | `2026-04-23T10:53:49Z` | `2026-04-23T10:53:49Z` | — same |
| `deal_products` | `deal_update_time` | `2026-04-24T05:58:45Z` | `2026-04-24T05:58:45Z` | — same |
| `dealflow` | `log_time` / `deal_update_time` | `2026-04-24T05:57:20Z` / `2026-04-24T05:58:45Z` | same | — same |
| `deals` | `update_time` | `2026-04-24T05:58:45Z` | `2026-04-24T05:58:45Z` | — same |
| `files` | `update_time` | `2026-04-24T05:58:44Z` | `2026-04-24T05:58:44Z` | — same |
| `filters` | `update_time` | `2020-01-01T00:00:00Z` | `2020-01-01T00:00:00Z` | — same |
| `notes` | `update_time` | `2026-04-24T05:55:20Z` | `2026-04-24T05:58:42Z` | ✅ **Advanced** |
| `organizations` | `update_time` | `2026-04-24T05:58:45Z` | `2026-04-24T05:58:45Z` | — same |
| `persons` | `update_time` | `2026-04-24T05:58:45Z` | `2026-04-24T05:58:45Z` | — same |
| `pipelines` | `update_time` | `2026-04-24T05:49:58Z` | `2026-04-24T05:49:58Z` | — same |
| `products` | `update_time` | `2026-04-24T05:50:03Z` | `2026-04-24T05:50:03Z` | — same |
| `stages` | `update_time` | `2026-04-24T05:50:02Z` | `2026-04-24T05:50:02Z` | — same |
| `users` | `modified` | `2026-04-23T10:54:01Z` | `2026-04-23T10:54:01Z` | — same |

---

## Observations

### Incrementally working correctly
All INCREMENTAL streams correctly replicated only the records modified after their bookmark timestamp.  
The `notes` bookmark advanced from `05:55:20Z` → `05:58:42Z`, and 103 records were replicated in that window — confirming the bookmark is being set and honoured accurately.

### FULL_TABLE streams
`currency` replicated 186 records in both runs — as expected for a FULL_TABLE stream with no replication key.

### Streams with stale bookmarks
`filters` and `deal_fields` have their bookmarks set to `2020-01-01T00:00:00Z` after both syncs. These streams appear to have no meaningful `update_time` on their records, so every run replicates them fully. This is a known limitation of the Pipedrive API for these resources.

---

## Verdict

**Incremental sync is functioning correctly.**  
Bookmarks are being persisted and applied as expected. No data loss or unexpected duplication was observed.

---
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
