### PR TITLE
Update bookmakring for ordered streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.0.1
+  * Fix bookmarking issue for notes stream [#157](https://github.com/singer-io/tap-pipedrive/pull/157)
+  * Bump requests from 2.32.4 to 2.33.0
+
 # 2.0.0
   * Update datatype for some of the schema fields [#152](https://github.com/singer-io/tap-pipedrive/pull/152)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="2.0.0",
+      version="2.0.1",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",
@@ -11,7 +11,7 @@ setup(name="tap-pipedrive",
       py_modules=["tap_pipedrive"],
       install_requires=[
           "pendulum==3.1.0",
-          "requests==2.32.4",
+          "requests==2.33.0",
           "singer-python==6.1.1",
       ],
       entry_points="""

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -242,6 +242,7 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
 
     sort_by = 'update_time'
     sort_direction = 'desc'
+    max_replication_key_value = None
 
     def update_request_params(self, params):
         """
@@ -262,26 +263,23 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
         Write the record to the stream
         """
         current_bookmark = row.get(self.state_field)
+        if not self.max_replication_key_value and current_bookmark:
+            # First record will have latest replication value.
+            self.max_replication_key_value = datetime.strptime(current_bookmark, "%Y-%m-%dT%H:%M:%S.000000Z").strftime("%Y-%m-%dT%H:%M:%SZ")
+
         if not current_bookmark or current_bookmark >= self.initial_state:
             return True
+
+        # Update the state only after the stream has been fully processed.
+        # Because some interruption happens, it would miss some records if we write bookmark in advance
+        self.earliest_state = self.max_replication_key_value
 
         # Stop fetching if the current replication value is less than the earliest state(bookmark)
         self.more_items_in_collection = False
         return False
 
     def update_state(self, row):
-        """
-        Update the state only after the stream has been fully processed.
-        Because it fetched all records in descending order, the first records will have latest replication value.
-        So if some interruption happens, it would miss some records.
-        """
-        if self.more_items_in_collection:
-            return
-
-        current_bookmark = row.get(self.state_field)
-        current_bookmark = datetime.strptime(current_bookmark, "%Y-%m-%dT%H:%M:%S.000000Z").strftime("%Y-%m-%dT%H:%M:%SZ") if current_bookmark else None
-        if current_bookmark and current_bookmark >= self.earliest_state:
-            self.earliest_state = current_bookmark
+        pass
 
 class DynamicSchemaStream(PipedriveStream):
     static_fields = []

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -272,7 +272,8 @@ class PipedriveIncrementalStreamUsingSort(PipedriveStream):
 
         # Update the state only after the stream has been fully processed.
         # Because some interruption happens, it would miss some records if we write bookmark in advance
-        self.earliest_state = self.max_replication_key_value
+        if self.max_replication_key_value and self.max_replication_key_value >= self.earliest_state:
+            self.earliest_state = self.max_replication_key_value
 
         # Stop fetching if the current replication value is less than the earliest state(bookmark)
         self.more_items_in_collection = False

--- a/tap_pipedrive/streams/notes.py
+++ b/tap_pipedrive/streams/notes.py
@@ -7,6 +7,7 @@ class NotesStream(DynamicSchemaStream, PipedriveIncrementalStreamUsingSort, Pipe
     key_properties = ['id']
     state_field = 'update_time'
     replication_method = 'INCREMENTAL'
+    max_replication_key_value = None
 
     def update_request_params(self, params):
         """

--- a/tap_pipedrive/streams/pipelines.py
+++ b/tap_pipedrive/streams/pipelines.py
@@ -7,3 +7,4 @@ class PipelinesStream(PipedriveIncrementalStreamUsingSort):
     replication_method = 'INCREMENTAL'
     state_field = 'update_time'
     cursor = None
+    max_replication_key_value = None

--- a/tap_pipedrive/streams/products.py
+++ b/tap_pipedrive/streams/products.py
@@ -8,3 +8,4 @@ class ProductsStream(DynamicSchemaStream, PipedriveIncrementalStreamUsingSort):
     replication_method = 'INCREMENTAL'
     state_field = 'update_time'
     cursor = None
+    max_replication_key_value = None

--- a/tap_pipedrive/streams/stages.py
+++ b/tap_pipedrive/streams/stages.py
@@ -7,3 +7,4 @@ class StagesStream(PipedriveIncrementalStreamUsingSort):
     replication_method = 'INCREMENTAL'
     state_field = 'update_time'
     cursor = None
+    max_replication_key_value = None

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -299,6 +299,15 @@ class PipedriveTap(object):
                                                    str(stream.earliest_state))
             singer.write_state(self.state)
 
+        # After pagination completes, update earliest_state if max_replication_key_value was captured
+        # This handles the case where all records are newer than the bookmark (no early termination)
+        if getattr(stream, 'max_replication_key_value', None) and stream.max_replication_key_value > stream.earliest_state:
+            stream.earliest_state = stream.max_replication_key_value
+            if stream.state_field:
+                self.state = singer.write_bookmark(self.state, stream.schema, stream.state_field,
+                                                   str(stream.earliest_state))
+                singer.write_state(self.state)
+
     def get_default_config(self):
         return CONFIG_DEFAULTS
 

--- a/tests/test_pipedrive_bookmarks.py
+++ b/tests/test_pipedrive_bookmarks.py
@@ -49,13 +49,13 @@ class PipedriveBookmarksTest(PipedriveBaseTest):
         ##########################################################################
         new_state = {'bookmarks': dict()}
         simulated_states = {
-            "notes": {"update_time": "2026-03-04T08:45:00Z"},
-            "activities": {"update_time": "2026-03-04T08:45:00Z"},
-            "deals": {"update_time": "2026-03-04T08:45:00Z"},
-            "files": {"update_time": "2026-03-04T08:45:00Z"},
-            "organizations": {"update_time": "2026-03-04T08:45:00Z"},
-            "persons": {"update_time": "2026-03-04T08:45:00Z"},
-            "products": {"update_time": "2026-03-04T08:45:00Z"},
+            "notes": {"update_time": "2026-04-29T00:00:00Z"},
+            "activities": {"update_time": "2026-04-29T00:00:00Z"},
+            "deals": {"update_time": "2026-04-29T00:00:00Z"},
+            "files": {"update_time": "2026-04-29T00:00:00Z"},
+            "organizations": {"update_time": "2026-04-29T00:00:00Z"},
+            "persons": {"update_time": "2026-04-29T00:00:00Z"},
+            "products": {"update_time": "2026-04-29T00:00:00Z"},
             # "dealflow": {"log_time": "2026-02-17T05:40:00Z"},
             # Skipping users - only 1 user, assertLess(1,1) can never pass
             # "users": {"modified": "2026-02-17T05:40:00Z"},

--- a/tests/test_pipedrive_start_date.py
+++ b/tests/test_pipedrive_start_date.py
@@ -4,7 +4,7 @@ from base import PipedriveBaseTest
 class PipedriveStartDateTest(PipedriveBaseTest):
 
     start_date_1 = ""
-    start_date_2 = "2026-03-05T00:00:00Z"
+    start_date_2 = "2026-04-29T00:00:00Z"
 
     @staticmethod
     def name():


### PR DESCRIPTION
# Description of change
Some streams endpoint return records in reverse order of replication_key value. So, first record will have latest replication value. Updating bookmarking issue so that tap writes that as first record replication value as bookmark at the end of complete sync.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
