### PR TITLE
[SAC-31191] - Unauthorized streams exclusion from catalog during discovery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: 'Coverage Report'
           command: |
             source /usr/local/share/virtualenvs/tap-pipedrive/bin/activate
-            coverage report -m --fail-under=99 | tee coverage.txt
+            coverage report -m --fail-under=99
             coverage html
       - store_test_results:
           path: test_output/report.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # 2.3.0
-  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.
+  * Streams that return 403 (Forbidden) during discovery are now excluded from the catalog. Discovery still raises an error if no supported streams are accessible.
   * Added unit tests for discovery access checks, bookmark read/write behavior, and sync orchestration.
 
 # 2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.3.0
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.
+  * Added unit tests for discovery access checks, bookmark read/write behavior, and sync orchestration.
+
 # 2.2.0
   * Adds parent-tap-stream-id field to catalog for child streams [#150](https://github.com/singer-io/tap-pipedrive/pull/150)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="tap-pipedrive",
-      version="2.2.0",
+    version="2.3.0",
       description="Singer.io tap for extracting data from the Pipedrive API",
       author="Stitch",
       author_email="dev@stitchdata.com",

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -148,11 +148,7 @@ class PipedriveStream(object):
         if self.initial_state is None:
             self.initial_state = self.tap.config.get('start_date')
 
-        try:
-            params = self.update_request_params(params)
-        except Exception:
-            # Fallback to a minimal probe if a stream-specific param builder fails.
-            pass
+        params = self.update_request_params(params)
 
         try:
             self.tap.execute_request(self.endpoint, self.api_version, params=params)

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -159,7 +159,7 @@ class PipedriveStream(object):
             return True
         except PipedriveForbiddenError as exc:
             logger.warning(
-                "Permission Error: Stream '%s' - %s",
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message:'%s'",
                 self.__class__.__name__,
                 exc,
             )

--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -3,6 +3,7 @@ import singer
 import pendulum
 from datetime import datetime
 from requests.exceptions import RequestException
+from .exceptions import PipedriveForbiddenError
 
 logger = singer.get_logger()
 
@@ -108,6 +109,45 @@ class PipedriveStream(object):
 
     def process_row(self, row):
         return row
+
+    def check_access(self):
+        """
+        Verify that the configured credentials can read this stream.
+        Child streams always return True and are pruned if their parent is excluded.
+        """
+        if getattr(self, 'parent', None):
+            return True
+
+        if not self.tap:
+            return True
+
+        params = {
+            'start': 0,
+            'limit': 1,
+        }
+
+        previous_initial_state = self.initial_state
+        if self.initial_state is None:
+            self.initial_state = self.tap.config.get('start_date')
+
+        try:
+            params = self.update_request_params(params)
+        except Exception:
+            # Fallback to a minimal probe if a stream-specific param builder fails.
+            pass
+
+        try:
+            self.tap.execute_request(self.endpoint, self.api_version, params=params)
+            return True
+        except PipedriveForbiddenError as exc:
+            logger.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.__class__.__name__,
+                exc,
+            )
+            return False
+        finally:
+            self.initial_state = previous_initial_state
 
 class PipedriveV1IncrementalStream(PipedriveStream):
     api_version = 'v1'

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -129,13 +129,60 @@ class PipedriveTap(object):
         self.config.update(config)
         self.state = state
 
+    def _prune_inaccessible_children(self, streams):
+        """
+        Remove child streams whose parent stream is not in the selected stream list.
+        """
+        allowed_schemas = {stream.schema for stream in streams}
+        pruned_streams = []
+
+        for stream in streams:
+            parent = getattr(stream, 'parent', None)
+            if parent and parent not in allowed_schemas:
+                logger.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    stream.schema,
+                    parent,
+                )
+                continue
+            pruned_streams.append(stream)
+
+        return pruned_streams
+
+    def _apply_access_checks(self):
+        """
+        Probe each stream for read access and exclude inaccessible parent streams.
+        """
+        accessible_streams = []
+        inaccessible_streams = []
+
+        for stream in self.streams:
+            stream.tap = self
+            if stream.check_access():
+                accessible_streams.append(stream)
+            else:
+                inaccessible_streams.append(stream.schema)
+
+        accessible_streams = self._prune_inaccessible_children(accessible_streams)
+
+        if not accessible_streams:
+            raise PipedriveForbiddenError(
+                "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
+            )
+        if inaccessible_streams:
+            logger.warning(
+                "No 'read' access to stream(s): %s. Excluded from catalog.",
+                ", ".join(inaccessible_streams),
+            )
+
+        return accessible_streams
+
     def do_discover(self):
         logger.info('Starting discover')
 
         catalog = Catalog([])
 
-        for stream in self.streams:
-            stream.tap = self
+        for stream in self._apply_access_checks():
 
             schema = Schema.from_dict(stream.get_schema())
             key_properties = stream.key_properties

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -172,7 +172,8 @@ class PipedriveTap(object):
             )
         if not accessible_streams:
             raise PipedriveForbiddenError(
-                "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
+                "HTTP-error-code: 403, Error: No accessible streams remain; "
+                "the credentials do not have 'read' access to any supported streams."
             )
         return accessible_streams
 
@@ -192,7 +193,7 @@ class PipedriveTap(object):
                 valid_replication_keys=[stream.state_field] if stream.state_field else None,
                 replication_method=stream.replication_method
             )
-            
+
             meta = metadata.to_map(meta)
             parent_attribute = getattr(stream, "parent", None)
             if parent_attribute:

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -131,7 +131,7 @@ class PipedriveTap(object):
 
     def _prune_inaccessible_children(self, streams):
         """
-        Remove child streams whose parent stream is not in the selected stream list.
+        Remove child streams whose parent stream is not present in the provided stream list.
         """
         allowed_schemas = {stream.schema for stream in streams}
         pruned_streams = []
@@ -173,7 +173,7 @@ class PipedriveTap(object):
             logger.warning(
                 "No 'read' access to stream(s): %s. Excluded from catalog.",
                 ", ".join(inaccessible_streams),
-            )
+            "Unauthorized streams excluded from catalog: %s",
 
         return accessible_streams
 

--- a/tap_pipedrive/tap.py
+++ b/tap_pipedrive/tap.py
@@ -165,16 +165,15 @@ class PipedriveTap(object):
 
         accessible_streams = self._prune_inaccessible_children(accessible_streams)
 
-        if not accessible_streams:
-            raise PipedriveForbiddenError(
-                "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
-            )
         if inaccessible_streams:
             logger.warning(
                 "No 'read' access to stream(s): %s. Excluded from catalog.",
                 ", ".join(inaccessible_streams),
-            "Unauthorized streams excluded from catalog: %s",
-
+            )
+        if not accessible_streams:
+            raise PipedriveForbiddenError(
+                "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
+            )
         return accessible_streams
 
     def do_discover(self):

--- a/tests/mockedtests/base.py
+++ b/tests/mockedtests/base.py
@@ -24,12 +24,17 @@ class FakeStream:
         self.endpoint = schema
         self.state_field = state_field
         self.replication_method = replication_method
+        self.parent = None
+        self.accessible = True
         self.key_properties = ["id"]
         self.more_items_in_collection = True
         self.initial_state = None
         self.earliest_state = None
         self.start = 0
         self.cursor = None
+
+    def check_access(self):
+        return self.accessible
 
     def get_schema(self):
         properties = {

--- a/tests/test_pipedrive_discovery.py
+++ b/tests/test_pipedrive_discovery.py
@@ -69,7 +69,7 @@ class PipedriveDiscovery(PipedriveBaseTest):
                 # Get parent-tap-stream-id if present
                 actual_parent_stream_id = stream_properties[0].get(
                     "metadata", {}).get(self.PARENT_TAP_STREAM_ID)
-                
+
                 expected_parent_stream = self.expected_metadata().get(
                     stream, {}).get(self.PARENT_TAP_STREAM_ID)
 

--- a/tests/unittests/test_bookmarks.py
+++ b/tests/unittests/test_bookmarks.py
@@ -1,0 +1,57 @@
+import unittest
+
+from tap_pipedrive.stream import PipedriveStream
+
+
+class BookmarkTestStream(PipedriveStream):
+    schema = "deals"
+    state_field = "update_time"
+
+
+class TestBookmarks(unittest.TestCase):
+
+    def setUp(self):
+        self.stream = BookmarkTestStream()
+
+    def test_set_initial_state_reads_existing_bookmark(self):
+        state = {
+            "bookmarks": {
+                "deals": {
+                    "update_time": "2024-01-02T00:00:00Z"
+                }
+            }
+        }
+
+        self.stream.set_initial_state(state, "2024-01-01T00:00:00Z")
+
+        self.assertEqual(self.stream.initial_state, "2024-01-02T00:00:00Z")
+        self.assertEqual(self.stream.earliest_state, "2024-01-02T00:00:00Z")
+
+    def test_set_initial_state_falls_back_to_start_date(self):
+        self.stream.set_initial_state({}, "2024-01-01T00:00:00Z")
+
+        self.assertEqual(self.stream.initial_state, "2024-01-01T00:00:00Z")
+        self.assertEqual(self.stream.earliest_state, "2024-01-01T00:00:00Z")
+
+    def test_update_state_advances_bookmark(self):
+        self.stream.earliest_state = "2024-01-01T00:00:00Z"
+        row = {"update_time": "2024-01-03T00:00:00.000000Z"}
+
+        self.stream.update_state(row)
+
+        self.assertEqual(self.stream.earliest_state, "2024-01-03T00:00:00Z")
+
+    def test_update_state_does_not_regress_bookmark(self):
+        self.stream.earliest_state = "2024-01-03T00:00:00Z"
+        row = {"update_time": "2024-01-02T00:00:00.000000Z"}
+
+        self.stream.update_state(row)
+
+        self.assertEqual(self.stream.earliest_state, "2024-01-03T00:00:00Z")
+
+    def test_write_record_filters_records_older_than_bookmark(self):
+        self.stream.initial_state = "2024-01-03T00:00:00Z"
+
+        self.assertFalse(self.stream.write_record({"update_time": "2024-01-02T00:00:00Z"}))
+        self.assertTrue(self.stream.write_record({"update_time": "2024-01-03T00:00:00Z"}))
+        self.assertTrue(self.stream.write_record({"update_time": "2024-01-04T00:00:00Z"}))

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from tap_pipedrive.stream import PipedriveStream
 from tap_pipedrive.tap import PipedriveTap
@@ -71,8 +72,21 @@ class TestDiscoveryAccessChecks(unittest.TestCase):
             FakeStream("dealflow", parent="deals", accessible=True),
         ]
 
-        with self.assertRaises(PipedriveForbiddenError) as error:
-            self.tap.do_discover()
+        with patch("tap_pipedrive.tap.logger.warning") as mock_warning:
+            with self.assertRaises(PipedriveForbiddenError) as error:
+                self.tap.do_discover()
+
+        self.assertTrue(
+            any(
+                call.args
+                and call.args[0] == "No 'read' access to stream(s): %s. Excluded from catalog."
+                and len(call.args) > 1
+                and "deals" in call.args[1]
+                and "users" in call.args[1]
+                for call in mock_warning.call_args_list
+            ),
+            "Expected inaccessible parent stream warning to include deals and users.",
+        )
 
         self.assertEqual(
             str(error.exception),

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,9 +1,13 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from tap_pipedrive.stream import PipedriveStream
 from tap_pipedrive.tap import PipedriveTap
-from tap_pipedrive.exceptions import PipedriveForbiddenError
+from tap_pipedrive.exceptions import (
+    PipedriveForbiddenError,
+    PipedriveTooManyRequestsError,
+    PipedriveUnauthorizedError,
+)
 
 
 class FakeStream(PipedriveStream):
@@ -13,10 +17,9 @@ class FakeStream(PipedriveStream):
     state_field = None
     replication_method = "FULL_TABLE"
 
-    def __init__(self, schema_name, parent=None, accessible=True):
+    def __init__(self, schema_name, parent=None):
         self.schema = schema_name
         self.parent = parent
-        self._accessible = accessible
 
     def get_schema(self):
         return {
@@ -26,12 +29,6 @@ class FakeStream(PipedriveStream):
             }
         }
 
-    def check_access(self):
-        if self.parent:
-            return True
-        return self._accessible
-
-
 class TestDiscoveryAccessChecks(unittest.TestCase):
 
     def setUp(self):
@@ -40,12 +37,13 @@ class TestDiscoveryAccessChecks(unittest.TestCase):
             "api_token": "abc",
         }
         self.tap = PipedriveTap(config, {})
+        self.tap.execute_request = MagicMock()
 
     def test_discovery_keeps_all_accessible_streams(self):
         self.tap.streams = [
-            FakeStream("deals", accessible=True),
-            FakeStream("dealflow", parent="deals", accessible=True),
-            FakeStream("users", accessible=True),
+            FakeStream("deals"),
+            FakeStream("dealflow", parent="deals"),
+            FakeStream("users"),
         ]
 
         catalog = self.tap.do_discover()
@@ -53,50 +51,72 @@ class TestDiscoveryAccessChecks(unittest.TestCase):
 
         self.assertSetEqual(discovered, {"deals", "dealflow", "users"})
 
-    def test_discovery_excludes_inaccessible_parent_and_child(self):
+    def test_discovery_excludes_forbidden_stream_and_keeps_authorized_streams(self):
         self.tap.streams = [
-            FakeStream("deals", accessible=False),
-            FakeStream("dealflow", parent="deals", accessible=True),
-            FakeStream("users", accessible=True),
+            FakeStream("deals"),
+            FakeStream("users"),
+        ]
+        self.tap.execute_request.side_effect = [
+            PipedriveForbiddenError("HTTP-error-code: 403, Error: insufficient permissions"),
+            MagicMock(),
         ]
 
-        catalog = self.tap.do_discover()
+        with self.assertLogs("root", level="WARNING") as logs:
+            catalog = self.tap.do_discover()
         discovered = {entry.tap_stream_id for entry in catalog.streams}
 
         self.assertSetEqual(discovered, {"users"})
+        self.assertEqual(self.tap.execute_request.call_count, 2)
+        self.assertIn("Unauthorized Stream: FakeStream", "\n".join(logs.output))
+        self.assertIn("HTTP-error-code: 403", "\n".join(logs.output))
+
+    def test_discovery_propagates_unauthorized_error_without_probing_more_streams(self):
+        self.tap.streams = [FakeStream("deals"), FakeStream("users")]
+        error = PipedriveUnauthorizedError("HTTP-error-code: 401, Error: invalid credentials")
+        self.tap.execute_request.side_effect = error
+
+        with patch("tap_pipedrive.stream.logger.warning") as warning:
+            with self.assertRaisesRegex(PipedriveUnauthorizedError, "401"):
+                self.tap.do_discover()
+
+        self.tap.execute_request.assert_called_once()
+        warning.assert_not_called()
+
+    def test_discovery_propagates_non_authorization_error_without_excluding_stream(self):
+        self.tap.streams = [FakeStream("deals"), FakeStream("users")]
+        error = PipedriveTooManyRequestsError("HTTP-error-code: 429, Error: rate limited")
+        self.tap.execute_request.side_effect = error
+
+        with patch("tap_pipedrive.stream.logger.warning") as warning:
+            with self.assertRaisesRegex(PipedriveTooManyRequestsError, "429"):
+                self.tap.do_discover()
+
+        self.tap.execute_request.assert_called_once()
+        warning.assert_not_called()
 
     def test_discovery_raises_when_no_parent_stream_is_accessible(self):
         self.tap.streams = [
-            FakeStream("deals", accessible=False),
-            FakeStream("users", accessible=False),
-            FakeStream("dealflow", parent="deals", accessible=True),
+            FakeStream("deals"),
+            FakeStream("users"),
+            FakeStream("dealflow", parent="deals"),
         ]
+        self.tap.execute_request.side_effect = PipedriveForbiddenError(
+            "HTTP-error-code: 403, Error: insufficient permissions"
+        )
 
-        with patch("tap_pipedrive.tap.logger.warning") as mock_warning:
-            with self.assertRaises(PipedriveForbiddenError) as error:
+        with self.assertLogs("root", level="WARNING") as logs:
+            with self.assertRaisesRegex(PipedriveForbiddenError, "No accessible streams remain"):
                 self.tap.do_discover()
 
-        self.assertTrue(
-            any(
-                call.args
-                and call.args[0] == "No 'read' access to stream(s): %s. Excluded from catalog."
-                and len(call.args) > 1
-                and "deals" in call.args[1]
-                and "users" in call.args[1]
-                for call in mock_warning.call_args_list
-            ),
-            "Expected inaccessible parent stream warning to include deals and users.",
-        )
-
-        self.assertEqual(
-            str(error.exception),
-            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams.",
-        )
+        self.assertEqual(self.tap.execute_request.call_count, 2)
+        output = "\n".join(logs.output)
+        self.assertIn("Stream 'dealflow' excluded", output)
+        self.assertIn("No 'read' access to stream(s): deals, users", output)
 
     def test_child_stream_contains_parent_tap_stream_id_metadata(self):
         self.tap.streams = [
-            FakeStream("deals", accessible=True),
-            FakeStream("dealflow", parent="deals", accessible=True),
+            FakeStream("deals"),
+            FakeStream("dealflow", parent="deals"),
         ]
 
         catalog = self.tap.do_discover()

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,96 @@
+import unittest
+
+from tap_pipedrive.stream import PipedriveStream
+from tap_pipedrive.tap import PipedriveTap
+from tap_pipedrive.exceptions import PipedriveForbiddenError
+
+
+class FakeStream(PipedriveStream):
+    endpoint = "fake"
+    api_version = "v1"
+    key_properties = ["id"]
+    state_field = None
+    replication_method = "FULL_TABLE"
+
+    def __init__(self, schema_name, parent=None, accessible=True):
+        self.schema = schema_name
+        self.parent = parent
+        self._accessible = accessible
+
+    def get_schema(self):
+        return {
+            "type": "object",
+            "properties": {
+                "id": {"type": ["integer", "null"]}
+            }
+        }
+
+    def check_access(self):
+        if self.parent:
+            return True
+        return self._accessible
+
+
+class TestDiscoveryAccessChecks(unittest.TestCase):
+
+    def setUp(self):
+        config = {
+            "start_date": "2017-01-01T00:00:00Z",
+            "api_token": "abc",
+        }
+        self.tap = PipedriveTap(config, {})
+
+    def test_discovery_keeps_all_accessible_streams(self):
+        self.tap.streams = [
+            FakeStream("deals", accessible=True),
+            FakeStream("dealflow", parent="deals", accessible=True),
+            FakeStream("users", accessible=True),
+        ]
+
+        catalog = self.tap.do_discover()
+        discovered = {entry.tap_stream_id for entry in catalog.streams}
+
+        self.assertSetEqual(discovered, {"deals", "dealflow", "users"})
+
+    def test_discovery_excludes_inaccessible_parent_and_child(self):
+        self.tap.streams = [
+            FakeStream("deals", accessible=False),
+            FakeStream("dealflow", parent="deals", accessible=True),
+            FakeStream("users", accessible=True),
+        ]
+
+        catalog = self.tap.do_discover()
+        discovered = {entry.tap_stream_id for entry in catalog.streams}
+
+        self.assertSetEqual(discovered, {"users"})
+
+    def test_discovery_raises_when_no_parent_stream_is_accessible(self):
+        self.tap.streams = [
+            FakeStream("deals", accessible=False),
+            FakeStream("users", accessible=False),
+            FakeStream("dealflow", parent="deals", accessible=True),
+        ]
+
+        with self.assertRaises(PipedriveForbiddenError) as error:
+            self.tap.do_discover()
+
+        self.assertEqual(
+            str(error.exception),
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams.",
+        )
+
+    def test_child_stream_contains_parent_tap_stream_id_metadata(self):
+        self.tap.streams = [
+            FakeStream("deals", accessible=True),
+            FakeStream("dealflow", parent="deals", accessible=True),
+        ]
+
+        catalog = self.tap.do_discover()
+        dealflow_entry = next(s for s in catalog.streams if s.tap_stream_id == "dealflow")
+        root_metadata = next(
+            item["metadata"]
+            for item in dealflow_entry.metadata
+            if item["breadcrumb"] in ([], ())
+        )
+
+        self.assertEqual(root_metadata.get("parent-tap-stream-id"), "deals")

--- a/tests/unittests/test_stream_coverage.py
+++ b/tests/unittests/test_stream_coverage.py
@@ -84,7 +84,7 @@ class TestStreamCoverageBranches(unittest.TestCase):
         self.assertIsNone(stream.initial_state)
         tap.execute_request.assert_called_once()
 
-    def test_check_access_uses_minimal_probe_when_param_builder_fails(self):
+    def test_check_access_propagates_param_builder_error(self):
         stream = _BaseStream()
         stream.endpoint = "deals"
         stream.initial_state = "2024-05-01T00:00:00Z"
@@ -92,14 +92,13 @@ class TestStreamCoverageBranches(unittest.TestCase):
 
         tap = MagicMock()
         tap.config = {"start_date": "2024-01-01T00:00:00Z"}
-        tap.execute_request.return_value = MagicMock()
         stream.tap = tap
 
         with patch.object(stream, "update_request_params", side_effect=RuntimeError("bad params")):
-            self.assertTrue(stream.check_access())
+            with self.assertRaisesRegex(RuntimeError, "bad params"):
+                stream.check_access()
 
-        call_kwargs = tap.execute_request.call_args.kwargs
-        self.assertEqual({"start": 0, "limit": 1}, call_kwargs["params"])
+        tap.execute_request.assert_not_called()
         self.assertEqual("2024-05-01T00:00:00Z", stream.initial_state)
 
     def test_check_access_returns_false_on_forbidden_and_restores_state(self):

--- a/tests/unittests/test_stream_coverage.py
+++ b/tests/unittests/test_stream_coverage.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from requests.exceptions import RequestException
+from tap_pipedrive.exceptions import PipedriveForbiddenError
 
 from tap_pipedrive.stream import (
     DynamicSchemaStream,
@@ -56,6 +57,64 @@ class TestStreamCoverageBranches(unittest.TestCase):
         params = stream.update_request_params({})
         self.assertEqual("cursor-1", params["cursor"])
         self.assertEqual("a,b", params["include_fields"])
+
+    def test_check_access_returns_true_for_child_stream(self):
+        stream = _BaseStream()
+        stream.parent = "deals"
+        self.assertTrue(stream.check_access())
+
+    def test_check_access_returns_true_when_tap_missing(self):
+        stream = _BaseStream()
+        stream.parent = None
+        stream.tap = None
+        self.assertTrue(stream.check_access())
+
+    def test_check_access_success_restores_initial_state(self):
+        stream = _BaseStream()
+        stream.endpoint = "deals"
+        stream.initial_state = None
+        stream.parent = None
+
+        tap = MagicMock()
+        tap.config = {"start_date": "2024-01-01T00:00:00Z"}
+        tap.execute_request.return_value = MagicMock()
+        stream.tap = tap
+
+        self.assertTrue(stream.check_access())
+        self.assertIsNone(stream.initial_state)
+        tap.execute_request.assert_called_once()
+
+    def test_check_access_uses_minimal_probe_when_param_builder_fails(self):
+        stream = _BaseStream()
+        stream.endpoint = "deals"
+        stream.initial_state = "2024-05-01T00:00:00Z"
+        stream.parent = None
+
+        tap = MagicMock()
+        tap.config = {"start_date": "2024-01-01T00:00:00Z"}
+        tap.execute_request.return_value = MagicMock()
+        stream.tap = tap
+
+        with patch.object(stream, "update_request_params", side_effect=RuntimeError("bad params")):
+            self.assertTrue(stream.check_access())
+
+        call_kwargs = tap.execute_request.call_args.kwargs
+        self.assertEqual({"start": 0, "limit": 1}, call_kwargs["params"])
+        self.assertEqual("2024-05-01T00:00:00Z", stream.initial_state)
+
+    def test_check_access_returns_false_on_forbidden_and_restores_state(self):
+        stream = _BaseStream()
+        stream.endpoint = "deals"
+        stream.initial_state = "2024-06-01T00:00:00Z"
+        stream.parent = None
+
+        tap = MagicMock()
+        tap.config = {"start_date": "2024-01-01T00:00:00Z"}
+        tap.execute_request.side_effect = PipedriveForbiddenError("forbidden")
+        stream.tap = tap
+
+        self.assertFalse(stream.check_access())
+        self.assertEqual("2024-06-01T00:00:00Z", stream.initial_state)
 
     @patch("tap_pipedrive.stream.singer.metrics.http_request_timer", return_value=_DummyTimer())
     @patch("tap_pipedrive.stream.singer.write_bookmark", side_effect=lambda state, *args, **kwargs: state)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest import mock
+
+from tap_pipedrive.stream import PipedriveStream
+from tap_pipedrive.tap import PipedriveTap
+
+
+class SyncTestStream(PipedriveStream):
+    schema = "users"
+    endpoint = "users"
+    state_field = "update_time"
+    replication_method = "INCREMENTAL"
+    key_properties = ["id"]
+
+    def has_data(self):
+        return False
+
+    def write_schema(self):
+        return None
+
+
+class StreamCatalogEntry:
+    schema = {"users": "users"}
+    metadata = []
+
+
+class FakeCatalog:
+    streams = []
+
+    def get_stream(self, stream_name):
+        return StreamCatalogEntry()
+
+
+class TestSync(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            "api_token": "abc",
+            "start_date": "2024-01-01T00:00:00Z",
+        }
+        self.tap = PipedriveTap(self.config, {})
+        self.tap.streams = [SyncTestStream()]
+
+    @mock.patch("singer.write_state")
+    @mock.patch("tap_pipedrive.tap.PipedriveTap.get_selected_streams", return_value=["users"])
+    def test_sync_sets_and_clears_currently_syncing(self, mocked_selected_streams, mocked_write_state):
+        self.tap.do_sync(FakeCatalog())
+
+        self.assertNotIn("currently_syncing", self.tap.state)
+        self.assertEqual(
+            self.tap.state.get("bookmarks", {}).get("users", {}).get("update_time"),
+            "2024-01-01T00:00:00Z",
+        )

--- a/tests/unittests/test_tap.py
+++ b/tests/unittests/test_tap.py
@@ -309,7 +309,8 @@ class TestDiscover(unittest.TestCase):
 
     @patch("tap_pipedrive.stream.DynamicSchemaStream.get_schema", return_value=_MOCK_SCHEMA)
     @patch("tap_pipedrive.stream.PipedriveStream.get_schema", return_value=_MOCK_SCHEMA)
-    def test_discover_returns_catalog_with_all_streams(self, mock_base, mock_dyn):
+    @patch("tap_pipedrive.stream.PipedriveStream.check_access", return_value=True)
+    def test_discover_returns_catalog_with_all_streams(self, mock_base, mock_dyn, mock_check_access):
         """do_discover returns a Catalog containing an entry for every configured stream."""
         tap = _make_tap()
         catalog = tap.do_discover()
@@ -320,7 +321,8 @@ class TestDiscover(unittest.TestCase):
 
     @patch("tap_pipedrive.stream.DynamicSchemaStream.get_schema", return_value=_MOCK_SCHEMA)
     @patch("tap_pipedrive.stream.PipedriveStream.get_schema", return_value=_MOCK_SCHEMA)
-    def test_discover_sets_key_properties(self, mock_base, mock_dyn):
+    @patch("tap_pipedrive.stream.PipedriveStream.check_access", return_value=True)
+    def test_discover_sets_key_properties(self, mock_base, mock_dyn, mock_check_access):
         """do_discover attaches the correct key_properties to each catalog entry."""
         tap = _make_tap()
         catalog = tap.do_discover()
@@ -329,7 +331,8 @@ class TestDiscover(unittest.TestCase):
 
     @patch("tap_pipedrive.stream.DynamicSchemaStream.get_schema", return_value=_MOCK_SCHEMA)
     @patch("tap_pipedrive.stream.PipedriveStream.get_schema", return_value=_MOCK_SCHEMA)
-    def test_discover_incremental_stream_has_replication_key_in_metadata(self, mock_base, mock_dyn):
+    @patch("tap_pipedrive.stream.PipedriveStream.check_access", return_value=True)
+    def test_discover_incremental_stream_has_replication_key_in_metadata(self, mock_base, mock_dyn, mock_check_access):
         """do_discover marks the replication key as automatic for incremental streams."""
         from singer import metadata
         tap = _make_tap()


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-31229
- Exclude unauthorized streams from catalog during discovery

# Manual QA steps
 - [ ]  Discovery: Creds unavailable
 - [ ]  Sync: Creds unavailable
 
# Rollback steps
 - revert this branch


